### PR TITLE
feat(admin): 입학 설명회 조회 개발

### DIFF
--- a/apps/admin/src/app/fair/[id]/page.tsx
+++ b/apps/admin/src/app/fair/[id]/page.tsx
@@ -11,7 +11,11 @@ import Link from 'next/link';
 import { Suspense } from 'react';
 import { styled } from 'styled-components';
 
-const FairDetailPage = () => {
+interface FairDetailProps {
+  id: number;
+}
+
+const FairDetailPage = ({ id }: FairDetailProps) => {
   return (
     <AppLayout>
       <StyledFairDetail>
@@ -20,7 +24,7 @@ const FairDetailPage = () => {
           돌아가기
         </DirectLink>
         <Suspense fallback={<Loader />}>
-          <FairDetail />
+          <FairDetail id={id} />
         </Suspense>
       </StyledFairDetail>
     </AppLayout>

--- a/apps/admin/src/app/fair/[id]/page.tsx
+++ b/apps/admin/src/app/fair/[id]/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import FairDetail from '@/components/fair/FairDetail/FairDetail';
+import { ROUTES } from '@/constants/common/constant';
+import AppLayout from '@/layouts/AppLayout';
+import { color, font } from '@maru/design-system';
+import { IconArrowLeft } from '@maru/icon';
+import { Loader } from '@maru/ui';
+import { flex } from '@maru/utils';
+import Link from 'next/link';
+import { Suspense } from 'react';
+import { styled } from 'styled-components';
+
+const FairDetailPage = () => {
+  return (
+    <AppLayout>
+      <StyledFairDetail>
+        <DirectLink href={ROUTES.FAIR}>
+          <IconArrowLeft width={18} height={18} />
+          돌아가기
+        </DirectLink>
+        <Suspense fallback={<Loader />}>
+          <FairDetail />
+        </Suspense>
+      </StyledFairDetail>
+    </AppLayout>
+  );
+};
+
+export default FairDetailPage;
+
+const StyledFairDetail = styled.div`
+  position: relative;
+  ${flex({ flexDirection: 'column' })}
+  gap: 24px;
+  width: 100%;
+  min-height: 100vh;
+  padding: 48px 60px;
+`;
+
+const DirectLink = styled(Link)`
+  ${flex({ alignItems: 'center' })};
+  gap: 2px;
+  ${font.p2};
+  color: ${color.gray600};
+`;

--- a/apps/admin/src/app/fair/page.tsx
+++ b/apps/admin/src/app/fair/page.tsx
@@ -1,10 +1,28 @@
+'use client';
+
+import FairList from '@/components/fair/FairList/FairList';
 import AppLayout from '@/layouts/AppLayout';
+import { Text } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { styled } from 'styled-components';
 
 const FairPage = () => {
   return (
     <AppLayout>
-      <div>입학설명회관리 페이지 에요.</div>
+      <StyledFairPage>
+        <Text fontType="H1">입학전형 설명회 관리</Text>
+        <FairList />
+      </StyledFairPage>
     </AppLayout>
   );
 };
 export default FairPage;
+
+const StyledFairPage = styled.div`
+  position: relative;
+  ${flex({ flexDirection: 'column' })}
+  gap: 65px;
+  width: 100%;
+  min-height: 100vh;
+  padding: 64px 60px 0 60px;
+`;

--- a/apps/admin/src/components/common/FunctionDropdown/FunctionDropdown.tsx
+++ b/apps/admin/src/components/common/FunctionDropdown/FunctionDropdown.tsx
@@ -83,6 +83,10 @@ const DropdownItemList = styled.div`
     justifyContent: 'flex-end',
     alignItems: 'flex-start',
   })}
+  z-index: 1;
+  position: absolute;
+  right: -12px;
+  margin-top: 24px;
   width: 280px;
   padding: 8px;
   background-color: ${color.white};

--- a/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
+++ b/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
@@ -9,50 +9,49 @@ import FairTable from '../FairTable/FairTable';
 import { Suspense } from 'react';
 import { useFairDetailQuery } from '@/services/fair/queries';
 import { formatDate } from '@/utils';
-import { FAIR_STATUS } from '@/constants/fair/constant';
-
-const data = [
-  {
-    icon: <IconUpload color="gray600" width={24} height={24} />,
-    label: '명단 엑셀로 내보내기',
-    value: 'execl',
-    onClick: () => {
-      // 현재 빈 함수
-    },
-  },
-];
+import { FAIR_ITEM_STATUS, FAIR_STATUS } from '@/constants/fair/constant';
+import { useExportExcelAction } from './fairDetail.hooks';
 
 interface FairDetailProps {
   id: number;
 }
 
 const FairDetail = ({ id }: FairDetailProps) => {
-  const { data: FairDetail } = useFairDetailQuery(id);
+  const { data: FairDetailData } = useFairDetailQuery(id);
+
+  const { handleExportExcelButtonClick } = useExportExcelAction(id);
 
   const statusType: StatusType =
-    FairDetail?.status === 'APPLICATION_ENDED'
-      ? 'full'
-      : FairDetail?.status === 'CLOSED' ||
-          FairDetail?.status === 'APPLICATION_EARLY_CLOSED'
-        ? 'closed'
-        : 'open';
+    FAIR_ITEM_STATUS[FairDetailData?.status as FairStatus] ?? 'open';
 
-  const FairAttendeeList = FairDetail?.attendeeList;
+  const Fairtitle = formatDate.toDayAndDateTime(FairDetailData?.start || '');
+  const FairAttendeeList = FairDetailData?.attendeeList;
 
-  return FairDetail ? (
+  return FairDetailData ? (
     <StyledFairDetail>
       <Row justifyContent="space-between">
         <Column gap={4}>
           <ItemStatusBox status={statusType}>
-            {FAIR_STATUS[FairDetail.status as FairStatus]}
+            {FAIR_STATUS[FairDetailData.status as FairStatus]}
           </ItemStatusBox>
           <Text fontType="H1">
-            {formatDate.toDayAndDateTime(FairDetail.start)}
+            {Fairtitle}
             <br />
             입학전형 설명회 조회
           </Text>
         </Column>
-        <FunctionDropdown data={data} />
+        <FunctionDropdown
+          data={[
+            {
+              icon: <IconUpload color="gray600" width={24} height={24} />,
+              label: '명단 엑셀로 내보내기',
+              value: 'execl',
+              onClick: () => {
+                handleExportExcelButtonClick(Fairtitle);
+              },
+            },
+          ]}
+        />
       </Row>
       <Suspense fallback={<Loader />}>
         <FairTable dataList={FairAttendeeList ?? []} />

--- a/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
+++ b/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
@@ -2,11 +2,10 @@ import { FairStatus, StatusType } from '@/types/fair/client';
 import { flex } from '@maru/utils';
 import { color } from '@maru/design-system';
 import { styled } from 'styled-components';
-import { Column, Loader, Row, Text } from '@maru/ui';
+import { Column, Row, Text } from '@maru/ui';
 import { FunctionDropdown } from '@/components/common';
 import { IconUpload } from '@maru/icon';
 import FairTable from '../FairTable/FairTable';
-import { Suspense } from 'react';
 import { useFairDetailQuery } from '@/services/fair/queries';
 import { formatDate } from '@/utils';
 import { FAIR_ITEM_STATUS, FAIR_STATUS } from '@/constants/fair/constant';
@@ -53,9 +52,7 @@ const FairDetail = ({ id }: FairDetailProps) => {
           ]}
         />
       </Row>
-      <Suspense fallback={<Loader />}>
-        <FairTable dataList={FairAttendeeList ?? []} />
-      </Suspense>
+      <FairTable dataList={FairAttendeeList ?? []} />
     </StyledFairDetail>
   ) : null;
 };

--- a/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
+++ b/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
@@ -1,0 +1,80 @@
+import { StatusType } from '@/types/fair/client';
+import { flex } from '@maru/utils';
+import { color } from '@maru/design-system';
+import { styled } from 'styled-components';
+import { Column, Row, Text } from '@maru/ui';
+import { FunctionDropdown } from '@/components/common';
+import { IconUpload } from '@maru/icon';
+import FairTable from '../FairTable/FairTable';
+
+const data = [
+  {
+    icon: <IconUpload color="gray600" width={24} height={24} />,
+    label: '명단 엑셀로 내보내기',
+    value: 'execl',
+    onClick: () => {
+      // 현재 빈 함수
+    },
+  },
+];
+
+const FairDetail = () => {
+  return (
+    <StyledFairDetail>
+      <Row justifyContent="space-between">
+        <Column gap={4}>
+          <ItemStatusBox status="open">신청 가능</ItemStatusBox>
+          <Text fontType="H1">
+            9월 19일
+            <br />
+            입학전형 설명회 조회
+          </Text>
+        </Column>
+        <FunctionDropdown data={data} />
+      </Row>
+      <FairTable id={1} />
+    </StyledFairDetail>
+  );
+};
+
+export default FairDetail;
+
+const StyledFairDetail = styled.div`
+  ${flex({ flexDirection: 'column' })}
+  width: 100%;
+  gap: 36px;
+`;
+
+const ItemStatusBox = styled.div<{ status: StatusType }>`
+  ${flex({ flexDirection: 'column', justifyContent: 'center' })}
+  display: inline-flex;
+  width: max-content;
+  height: 32px;
+  padding: 0 10px;
+  gap: 10px;
+  border-radius: 100px;
+  ${({ status }) => {
+    switch (status) {
+      case 'open':
+        return `
+          color: ${color.maruDefault};
+          border: 1px solid ${color.maruDefault};
+          background: rgba(37, 124, 255, 0.10);
+        `;
+      case 'closed':
+        return `
+          color: ${color.red};
+          border: 1px solid ${color.red};
+          background: rgba(244, 67, 54, 0.10);
+        `;
+      case 'full':
+        return `
+          color: ${color.gray700};
+          border: 1px solid ${color.gray700};
+          background: rgba(89, 91, 102, 0.10);
+        `;
+      default:
+        return '';
+    }
+  }}
+`;

--- a/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
+++ b/apps/admin/src/components/fair/FairDetail/FairDetail.tsx
@@ -46,7 +46,7 @@ const StyledFairDetail = styled.div`
 `;
 
 const ItemStatusBox = styled.div<{ status: StatusType }>`
-  ${flex({ flexDirection: 'column', justifyContent: 'center' })}
+  ${flex({ justifyContent: 'center', alignItems: 'center' })}
   display: inline-flex;
   width: max-content;
   height: 32px;

--- a/apps/admin/src/components/fair/FairDetail/fairDetail.hooks.ts
+++ b/apps/admin/src/components/fair/FairDetail/fairDetail.hooks.ts
@@ -1,0 +1,21 @@
+import { useFairExportExcelQuery } from '@/services/fair/queries';
+
+export const useExportExcelAction = (id: number) => {
+  const { data: exportExcelData } = useFairExportExcelQuery(id);
+
+  const handleExportExcelButtonClick = (title: string) => {
+    if (!exportExcelData) return;
+    const excelUrl = window.URL.createObjectURL(new Blob([exportExcelData]));
+
+    const link = document.createElement('a');
+    link.href = excelUrl;
+    const sanitizedTitle = title.replace(/\s+/g, '_');
+    link.download = `${sanitizedTitle}_입학설명회_신청자_명단.xlsx`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(excelUrl);
+  };
+
+  return { handleExportExcelButtonClick };
+};

--- a/apps/admin/src/components/fair/FairList/FairList.tsx
+++ b/apps/admin/src/components/fair/FairList/FairList.tsx
@@ -1,0 +1,35 @@
+import { useFairListQuery } from '@/services/fair/queries';
+import { flex } from '@maru/utils';
+import { styled } from 'styled-components';
+import FairListItem from './FairListItem/FairListItem';
+
+const FairList = () => {
+  const { data: fairListData } = useFairListQuery();
+
+  return (
+    <StyledFairList>
+      {fairListData?.map(
+        ({ id, start, place, applicationStartDate, applicationEndDate, status }) => (
+          <FairListItem
+            key={id}
+            id={id}
+            start={start}
+            place={place}
+            applicationStartDate={applicationStartDate}
+            applicationEndDate={applicationEndDate}
+            status={status}
+          />
+        )
+      )}
+    </StyledFairList>
+  );
+};
+
+export default FairList;
+
+const StyledFairList = styled.div`
+  ${flex({ alignItems: 'flex-start' })}
+  align-content: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+`;

--- a/apps/admin/src/components/fair/FairList/FairList.tsx
+++ b/apps/admin/src/components/fair/FairList/FairList.tsx
@@ -2,13 +2,23 @@ import { useFairListQuery } from '@/services/fair/queries';
 import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
 import FairListItem from './FairListItem/FairListItem';
+import FairListHeader from './FairListHeader/FairListHeader';
+import { useState } from 'react';
+import { FAIR_TAP_STATUS } from '@/constants/fair/constant';
 
 const FairList = () => {
+  const [tabStatus, setTabStatus] = useState('진행 중인 신청');
+
   const { data: fairListData } = useFairListQuery();
+
+  const filteredFairList = fairListData?.filter(({ status }) =>
+    FAIR_TAP_STATUS[tabStatus]?.includes(status)
+  );
 
   return (
     <StyledFairList>
-      {fairListData?.map(
+      <FairListHeader selectedTab={tabStatus} handleTabClick={setTabStatus} />
+      {filteredFairList?.map(
         ({ id, start, place, applicationStartDate, applicationEndDate, status }) => (
           <FairListItem
             key={id}

--- a/apps/admin/src/components/fair/FairList/FairList.tsx
+++ b/apps/admin/src/components/fair/FairList/FairList.tsx
@@ -1,10 +1,10 @@
 import { useFairListQuery } from '@/services/fair/queries';
-import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
 import FairListItem from './FairListItem/FairListItem';
 import FairListHeader from './FairListHeader/FairListHeader';
 import { useState } from 'react';
 import { FAIR_TAP_STATUS } from '@/constants/fair/constant';
+import { Column } from '@maru/ui';
 
 const FairList = () => {
   const [tabStatus, setTabStatus] = useState('진행 중인 신청');
@@ -16,30 +16,31 @@ const FairList = () => {
   );
 
   return (
-    <StyledFairList>
+    <Column width="100%" gap={64}>
       <FairListHeader selectedTab={tabStatus} handleTabClick={setTabStatus} />
-      {filteredFairList?.map(
-        ({ id, start, place, applicationStartDate, applicationEndDate, status }) => (
-          <FairListItem
-            key={id}
-            id={id}
-            start={start}
-            place={place}
-            applicationStartDate={applicationStartDate}
-            applicationEndDate={applicationEndDate}
-            status={status}
-          />
-        )
-      )}
-    </StyledFairList>
+      <StyledFairList>
+        {filteredFairList?.map(
+          ({ id, start, place, applicationStartDate, applicationEndDate, status }) => (
+            <FairListItem
+              key={id}
+              id={id}
+              start={start}
+              place={place}
+              applicationStartDate={applicationStartDate}
+              applicationEndDate={applicationEndDate}
+              status={status}
+            />
+          )
+        )}
+      </StyledFairList>
+    </Column>
   );
 };
 
 export default FairList;
 
 const StyledFairList = styled.div`
-  ${flex({ alignItems: 'flex-start' })}
-  align-content: flex-start;
-  gap: 16px;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 400px);
+  gap: 32px;
 `;

--- a/apps/admin/src/components/fair/FairList/FairListHeader/FairListHeader.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListHeader/FairListHeader.tsx
@@ -1,0 +1,55 @@
+import { ROUTES } from '@/constants/common/constant';
+import { color } from '@maru/design-system';
+import { Button, Row, UnderlineButton } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { useRouter } from 'next/navigation';
+import { styled } from 'styled-components';
+
+const NAVIGATION_LIST = [
+  {
+    name: '진행 중인 신청',
+  },
+  {
+    name: '마감된 신청',
+  },
+];
+
+interface FairListHeaderProps {
+  selectedTab: string;
+  handleTabClick: (name: string) => void;
+}
+
+const FairListHeader = ({ selectedTab, handleTabClick }: FairListHeaderProps) => {
+  const router = useRouter();
+
+  const handleMoveFairCreatePage = () => {
+    router.push(ROUTES.FAIR_CREATE);
+  };
+
+  return (
+    <StyledFairListHeader>
+      <Row>
+        {NAVIGATION_LIST.map(({ name }) => (
+          <UnderlineButton
+            key={`navigation ${name}`}
+            active={name === selectedTab}
+            onClick={() => handleTabClick(name)}
+          >
+            {name}
+          </UnderlineButton>
+        ))}
+      </Row>
+      <Button onClick={handleMoveFairCreatePage} icon="ADD_ICON">
+        입학 설명회 생성
+      </Button>
+    </StyledFairListHeader>
+  );
+};
+
+export default FairListHeader;
+
+const StyledFairListHeader = styled.div`
+  width: 100%;
+  ${flex({ alignItems: 'center', justifyContent: 'space-between' })}
+  background-color: ${color.white};
+`;

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -1,14 +1,12 @@
 import { ROUTES } from '@/constants/common/constant';
 import { FAIR_STATUS } from '@/constants/fair/constant';
-import { FairStatus } from '@/types/fair/client';
+import { FairStatus, StatusType } from '@/types/fair/client';
 import { formatDate } from '@/utils';
 import { color } from '@maru/design-system';
 import { Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { useRouter } from 'next/navigation';
 import { styled } from 'styled-components';
-
-type StatusType = 'open' | 'closed' | 'full';
 
 interface FairListItemProps {
   id: number;

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -1,6 +1,7 @@
 import { ROUTES } from '@/constants/common/constant';
 import { FAIR_STATUS } from '@/constants/fair/constant';
 import { FairStatus } from '@/types/fair/client';
+import formatDate from '@/utils/functions/formatDate';
 import { color } from '@maru/design-system';
 import { Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
@@ -42,7 +43,7 @@ const FairListItem = ({
     <StyledFairListItem onClick={handleMoveFairDetail}>
       <Row justifyContent="space-between" alignItems="center">
         <Text fontType="H3" color={color.gray900}>
-          {start}
+          {formatDate.toDayAndDateTime(start)}
         </Text>
         <ItemStatusBox status={statusType}>
           <Text fontType="context">{FAIR_STATUS[status as FairStatus]}</Text>
@@ -51,7 +52,8 @@ const FairListItem = ({
       <Column>
         <Text fontType="p2" color={color.gray500}>
           장소: {place} <br />
-          신청 기한: {applicationStartDate} ~ {applicationEndDate}
+          신청 기한: {formatDate.toDotDate(applicationStartDate)} ~{' '}
+          {formatDate.toDotDate(applicationEndDate)}
         </Text>
       </Column>
     </StyledFairListItem>

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -1,0 +1,96 @@
+import { ROUTES } from '@/constants/common/constant';
+import { FAIR_STATUS } from '@/constants/fair/constant';
+import { FairStatus } from '@/types/fair/client';
+import { color } from '@maru/design-system';
+import { Column, Row, Text } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { useRouter } from 'next/navigation';
+import { styled } from 'styled-components';
+
+type StatusType = 'open' | 'closed' | 'full';
+
+interface FairListItemProps {
+  id: number;
+  start: string;
+  place: string;
+  applicationStartDate: string;
+  applicationEndDate: string;
+  status: FairStatus;
+}
+
+const FairListItem = ({
+  id,
+  start,
+  place,
+  applicationStartDate,
+  applicationEndDate,
+  status,
+}: FairListItemProps) => {
+  const router = useRouter();
+  const statusType: StatusType =
+    status === 'APPLICATION_ENDED'
+      ? 'full'
+      : status === 'CLOSED' || status === 'APPLICATION_EARLY_CLOSED'
+        ? 'closed'
+        : 'open';
+
+  const handleMoveFairDetail = () => {
+    router.push(`${ROUTES}/${id}`);
+  };
+
+  return (
+    <StyledFairListItem onClick={handleMoveFairDetail}>
+      <Row justifyContent="space-between" alignItems="center">
+        <Text fontType="H3" color={color.gray900}>
+          {start}
+        </Text>
+        <ItemStatusBox status={statusType}>
+          <Text fontType="context">{FAIR_STATUS[status as FairStatus]}</Text>
+        </ItemStatusBox>
+      </Row>
+      <Column>
+        <Text fontType="p2" color={color.gray500}>
+          장소: {place} <br />
+          신청 기한: {applicationStartDate} ~ {applicationEndDate}
+        </Text>
+      </Column>
+    </StyledFairListItem>
+  );
+};
+export default FairListItem;
+
+const StyledFairListItem = styled.div`
+  ${flex({ flexDirection: 'column', justifyContent: 'space-between' })}
+  width: 400px;
+  padding: 24px 32px;
+`;
+
+const ItemStatusBox = styled.div<{ status: StatusType }>`
+  ${flex({ justifyContent: 'center' })}
+  gap: 10px;
+  border-radius: 100px;
+  ${({ status }) => {
+    switch (status) {
+      case 'open':
+        return `
+          color: ${color.maruDefault};
+          border: 1px solid ${color.maruDefault};
+          background: rgba(37, 124, 255, 0.10);
+        `;
+      case 'closed':
+        return `
+          color: ${color.red};
+          border: 1px solid ${color.red};
+          background: rgba(244, 67, 54, 0.10);
+        `;
+      case 'full':
+        return `
+          color: ${color.gray700};
+          border: 1px solid ${color.gray700};
+          background: rgba(89, 91, 102, 0.10);
+        `;
+      default:
+        return '';
+    }
+  }}
+`;

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -1,7 +1,7 @@
 import { ROUTES } from '@/constants/common/constant';
 import { FAIR_STATUS } from '@/constants/fair/constant';
 import { FairStatus } from '@/types/fair/client';
-import formatDate from '@/utils/functions/formatDate';
+import { formatDate } from '@/utils';
 import { color } from '@maru/design-system';
 import { Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -1,5 +1,5 @@
 import { ROUTES } from '@/constants/common/constant';
-import { FAIR_STATUS } from '@/constants/fair/constant';
+import { FAIR_ITEM_STATUS, FAIR_STATUS } from '@/constants/fair/constant';
 import { FairStatus, StatusType } from '@/types/fair/client';
 import { formatDate } from '@/utils';
 import { color } from '@maru/design-system';
@@ -26,12 +26,7 @@ const FairListItem = ({
   status,
 }: FairListItemProps) => {
   const router = useRouter();
-  const statusType: StatusType =
-    status === 'APPLICATION_ENDED'
-      ? 'full'
-      : status === 'CLOSED' || status === 'APPLICATION_EARLY_CLOSED'
-        ? 'closed'
-        : 'open';
+  const statusType: StatusType = FAIR_ITEM_STATUS[status as FairStatus] ?? 'open';
 
   const handleMoveFairDetail = () => {
     router.push(`${ROUTES.FAIR}/${id}`);

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -34,7 +34,7 @@ const FairListItem = ({
         : 'open';
 
   const handleMoveFairDetail = () => {
-    router.push(`${ROUTES}/${id}`);
+    router.push(`${ROUTES.FAIR}/${id}`);
   };
 
   return (
@@ -66,6 +66,7 @@ const StyledFairListItem = styled.div`
   border-radius: 12px;
   border: 1px solid ${color.gray200};
   background: ${color.white};
+  cursor: pointer;
 `;
 
 const ItemStatusBox = styled.div<{ status: StatusType }>`

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -69,7 +69,11 @@ const StyledFairListItem = styled.div`
 `;
 
 const ItemStatusBox = styled.div<{ status: StatusType }>`
-  ${flex({ justifyContent: 'center' })}
+  ${flex({ justifyContent: 'center', alignItems: 'center' })}
+  display: inline-flex;
+  width: max-content;
+  height: 32px;
+  padding: 0 10px;
   gap: 10px;
   border-radius: 100px;
   ${({ status }) => {

--- a/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
+++ b/apps/admin/src/components/fair/FairList/FairListItem/FairListItem.tsx
@@ -65,6 +65,9 @@ const StyledFairListItem = styled.div`
   ${flex({ flexDirection: 'column', justifyContent: 'space-between' })}
   width: 400px;
   padding: 24px 32px;
+  border-radius: 12px;
+  border: 1px solid ${color.gray200};
+  background: ${color.white};
 `;
 
 const ItemStatusBox = styled.div<{ status: StatusType }>`

--- a/apps/admin/src/components/fair/FairTable/FairQuestionModal/FairQuestionModal.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairQuestionModal/FairQuestionModal.tsx
@@ -1,0 +1,87 @@
+import { color, font } from '@maru/design-system';
+import { IconClose } from '@maru/icon';
+import { Button, Column, Row, Text } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { styled } from 'styled-components';
+
+interface FairQuestionModalProps {
+  name: string;
+  question: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FairQuestionModal = ({
+  name,
+  question,
+  isOpen,
+  onClose,
+}: FairQuestionModalProps) => {
+  return (
+    <BlurBackground isOpen={isOpen}>
+      <StyledFairQuestionModal>
+        <Column gap={20}>
+          <Row justifyContent="space-between">
+            <Text fontType="H2">{name}님의 질문</Text>
+            <IconClose
+              width={36}
+              height={36}
+              color={color.gray600}
+              cursor="pointer"
+              onClick={onClose}
+            />
+          </Row>
+          <Underline />
+          <QuestionText>{question}</QuestionText>
+        </Column>
+        <Row justifyContent="flex-end">
+          <Button size="SMALL" styleType="SECONDARY" width={60} onClick={onClose}>
+            닫기
+          </Button>
+        </Row>
+      </StyledFairQuestionModal>
+    </BlurBackground>
+  );
+};
+
+export default FairQuestionModal;
+
+const BlurBackground = styled.div<{ isOpen: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: ${(props) => (props.isOpen ? 'flex' : 'none')};
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1;
+`;
+
+const StyledFairQuestionModal = styled.div`
+  ${flex({
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+  })}
+  width: 600px;
+  padding: 36px;
+  min-height: 350px;
+
+  border-radius: 16px;
+  background: ${color.white};
+`;
+
+const Underline = styled.div`
+  width: 100%;
+  height: 1px;
+  border-bottom: 1px solid ${color.gray200};
+`;
+
+const QuestionText = styled.div`
+  width: 100%;
+  max-height: 200px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  ${font.p2}
+`;

--- a/apps/admin/src/components/fair/FairTable/FairTable.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTable.tsx
@@ -1,20 +1,17 @@
 import { Column } from '@maru/ui';
 import FairTableHeader from './FairTableHeader/FairTableHeader';
 import FairTableItem from './FairTableItem/FairTableItem';
-import { useFairDetailQuery } from '@/services/fair/queries';
+import { AttendeeData } from '@/types/fair/client';
 
 interface FairTableProps {
-  id: number;
+  dataList: AttendeeData[];
 }
 
-const FairTable = ({ id }: FairTableProps) => {
-  const { data: FairDetail } = useFairDetailQuery(id);
-  const FairAttendeeList = FairDetail?.attendeeList;
-
+const FairTable = ({ dataList }: FairTableProps) => {
   return (
     <Column gap={12}>
       <FairTableHeader />
-      {FairAttendeeList?.map(
+      {dataList?.map(
         ({ schoolName, name, type, phoneNumber, headcount, question }, index) => (
           <FairTableItem
             key={index}

--- a/apps/admin/src/components/fair/FairTable/FairTable.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTable.tsx
@@ -1,0 +1,53 @@
+import { Column } from '@maru/ui';
+import FairTableHeader from './FairTableHeader/FairTableHeader';
+import FairTableItem from './FairTableItem/FairTableItem';
+
+const fairList = [
+  {
+    schoolName: '비전중학교',
+    name: '곰밤돌',
+    type: '학생',
+    phoneNumber: '01028610200',
+    headcount: 2,
+    question: '내신 커트라인 몇인가요?',
+  },
+  {
+    schoolName: '비전중학교',
+    name: '곰밤돌',
+    type: '학생',
+    phoneNumber: '01030050921',
+    headcount: 2,
+    question: '내신 커트라인 몇인가요?',
+  },
+  {
+    schoolName: '비전중학교',
+    name: '곰밤돌',
+    type: '학생',
+    phoneNumber: '01049463364',
+    headcount: 2,
+    question: '내신 커트라인 몇인가요?',
+  },
+];
+
+const FairTable = () => {
+  return (
+    <Column gap={12}>
+      <FairTableHeader />
+      {fairList.map(
+        ({ schoolName, name, type, phoneNumber, headcount, question }, index) => (
+          <FairTableItem
+            key={index}
+            schoolName={schoolName}
+            name={name}
+            type={type}
+            phoneNumber={phoneNumber}
+            headcount={headcount}
+            question={question}
+          />
+        )
+      )}
+    </Column>
+  );
+};
+
+export default FairTable;

--- a/apps/admin/src/components/fair/FairTable/FairTable.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTable.tsx
@@ -1,39 +1,20 @@
 import { Column } from '@maru/ui';
 import FairTableHeader from './FairTableHeader/FairTableHeader';
 import FairTableItem from './FairTableItem/FairTableItem';
+import { useFairDetailQuery } from '@/services/fair/queries';
 
-const fairList = [
-  {
-    schoolName: '비전중학교',
-    name: '곰밤돌',
-    type: '학생',
-    phoneNumber: '01028610200',
-    headcount: 2,
-    question: '내신 커트라인 몇인가요?',
-  },
-  {
-    schoolName: '비전중학교',
-    name: '곰밤돌',
-    type: '학생',
-    phoneNumber: '01030050921',
-    headcount: 2,
-    question: '내신 커트라인 몇인가요?',
-  },
-  {
-    schoolName: '비전중학교',
-    name: '곰밤돌',
-    type: '학생',
-    phoneNumber: '01049463364',
-    headcount: 2,
-    question: '내신 커트라인 몇인가요?',
-  },
-];
+interface FairTableProps {
+  id: number;
+}
 
-const FairTable = () => {
+const FairTable = ({ id }: FairTableProps) => {
+  const { data: FairDetail } = useFairDetailQuery(id);
+  const FairAttendeeList = FairDetail?.attendeeList;
+
   return (
     <Column gap={12}>
       <FairTableHeader />
-      {fairList.map(
+      {FairAttendeeList?.map(
         ({ schoolName, name, type, phoneNumber, headcount, question }, index) => (
           <FairTableItem
             key={index}

--- a/apps/admin/src/components/fair/FairTable/FairTableHeader/FairTableHeader.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableHeader/FairTableHeader.tsx
@@ -1,0 +1,33 @@
+import TableHeader from '@/components/common/TableHeader/TableHeader';
+import { Row, Text } from '@maru/ui';
+
+const FairTableHeader = () => {
+  return (
+    <TableHeader>
+      <Row gap={48}>
+        <Text fontType="p2" width={60}>
+          이름
+        </Text>
+        <Text fontType="p2" width={60}>
+          참석 인원
+        </Text>
+        <Text fontType="p2" width={60}>
+          신청 유형
+        </Text>
+        <Text fontType="p2" width={293}>
+          학교
+        </Text>
+      </Row>
+      <Row gap={48}>
+        <Text fontType="p2" width={120}>
+          연락처
+        </Text>
+        <Text fontType="p2" width={120}>
+          질문
+        </Text>
+      </Row>
+    </TableHeader>
+  );
+};
+
+export default FairTableHeader;

--- a/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
@@ -1,6 +1,8 @@
 import { TableItem } from '@/components/common';
 import { formatPhoneNumber } from '@/utils';
-import { Row, Text } from '@maru/ui';
+import { Row, Text, TextButton } from '@maru/ui';
+import FairQuestionModal from '../FairQuestionModal/FairQuestionModal';
+import { useOverlay } from '@toss/use-overlay';
 
 interface FairTableItemProps {
   schoolName: string;
@@ -19,6 +21,19 @@ const FairTableItem = ({
   headcount,
   question,
 }: FairTableItemProps) => {
+  const overlay = useOverlay();
+
+  const handleFairQuestionModalButtonClick = () => {
+    overlay.open(({ isOpen, close }) => (
+      <FairQuestionModal
+        name={name}
+        question={question}
+        isOpen={isOpen}
+        onClose={close}
+      />
+    ));
+  };
+
   return (
     <TableItem>
       <Row gap={48}>
@@ -39,9 +54,14 @@ const FairTableItem = ({
         <Text fontType="p2" width={120}>
           {formatPhoneNumber(phoneNumber)}
         </Text>
-        <Text fontType="p2" width={120} ellipsis={true}>
+        <TextButton
+          fontType="p2"
+          width={120}
+          ellipsis={true}
+          onClick={handleFairQuestionModalButtonClick}
+        >
           {question}
-        </Text>
+        </TextButton>
       </Row>
     </TableItem>
   );

--- a/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
@@ -3,7 +3,6 @@ import { formatPhoneNumber } from '@/utils';
 import { Row, Text } from '@maru/ui';
 
 interface FairTableItemProps {
-  id: number;
   schoolName: string;
   name: string;
   type: string;
@@ -13,7 +12,6 @@ interface FairTableItemProps {
 }
 
 const FairTableItem = ({
-  id,
   schoolName,
   name,
   type,
@@ -22,7 +20,7 @@ const FairTableItem = ({
   question,
 }: FairTableItemProps) => {
   return (
-    <TableItem key={id}>
+    <TableItem>
       <Row gap={48}>
         <Text fontType="p2" width={60}>
           {name}

--- a/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
@@ -39,7 +39,7 @@ const FairTableItem = ({
         <Text fontType="p2" width={120}>
           {formatPhoneNumber(phoneNumber)}
         </Text>
-        <Text fontType="p2" width={120}>
+        <Text fontType="p2" width={120} ellipsis={true}>
           {question}
         </Text>
       </Row>

--- a/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
@@ -1,0 +1,52 @@
+import { TableItem } from '@/components/common';
+import { formatPhoneNumber } from '@/utils';
+import { Row, Text } from '@maru/ui';
+
+interface FairTableItemProps {
+  id: number;
+  schoolName: string;
+  name: string;
+  type: string;
+  phoneNumber: string;
+  headcount: number;
+  question: string;
+}
+
+const FairTableItem = ({
+  id,
+  schoolName,
+  name,
+  type,
+  phoneNumber,
+  headcount,
+  question,
+}: FairTableItemProps) => {
+  return (
+    <TableItem key={id}>
+      <Row gap={48}>
+        <Text fontType="p2" width={60}>
+          {name}
+        </Text>
+        <Text fontType="p2" width={60}>
+          {headcount}
+        </Text>
+        <Text fontType="p2" width={60}>
+          {type}
+        </Text>
+        <Text fontType="p2" width={293}>
+          {schoolName}
+        </Text>
+      </Row>
+      <Row gap={48}>
+        <Text fontType="p2" width={120}>
+          {formatPhoneNumber(phoneNumber)}
+        </Text>
+        <Text fontType="p2" width={120}>
+          {question}
+        </Text>
+      </Row>
+    </TableItem>
+  );
+};
+
+export default FairTableItem;

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -2,6 +2,7 @@ export const KEY = {
   ADMIN: 'useAdmin',
 
   FAIR_LIST: 'useFairList',
+  FAIR_DETAIL: 'useFairDetail',
 
   NOTICE_LIST: 'useNoticeList',
   NOTICE_DETAIL: 'useNoticeDetail',

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -1,6 +1,8 @@
 export const KEY = {
   ADMIN: 'useAdmin',
 
+  FAIR_LIST: 'useFairList',
+
   NOTICE_LIST: 'useNoticeList',
   NOTICE_DETAIL: 'useNoticeDetail',
 

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -20,6 +20,7 @@ export const ROUTES = {
   MESSAGE: '/message',
   ANALYSIS: '/analysis',
   FAIR: '/fair',
+  FAIR_CREATE: '/fair/create',
   REGISTRATION: '/registration',
 } as const;
 

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -3,6 +3,7 @@ export const KEY = {
 
   FAIR_LIST: 'useFairList',
   FAIR_DETAIL: 'useFairDetail',
+  FAIR_EXPORT_EXCEL: 'useFairExportExcel',
 
   NOTICE_LIST: 'useNoticeList',
   NOTICE_DETAIL: 'useNoticeDetail',

--- a/apps/admin/src/constants/fair/constant.ts
+++ b/apps/admin/src/constants/fair/constant.ts
@@ -1,4 +1,4 @@
-import { FairStatus } from '@/types/fair/client';
+import { FairStatus, StatusType } from '@/types/fair/client';
 
 export const FAIR_STATUS: Record<FairStatus, string> = {
   APPLICATION_ENDED: '신청 종료',
@@ -15,4 +15,12 @@ export const FAIR_TAP_STATUS: Record<string, string[]> = {
     'APPLICATION_ENDED',
   ],
   '마감된 신청': ['CLOSED', 'APPLICATION_EARLY_CLOSED'],
+};
+
+export const FAIR_ITEM_STATUS: Record<FairStatus, StatusType> = {
+  APPLICATION_ENDED: 'full',
+  CLOSED: 'closed',
+  APPLICATION_EARLY_CLOSED: 'closed',
+  APPLICATION_IN_PROGRESS: 'open',
+  APPLICATION_NOT_STARTED: 'open',
 };

--- a/apps/admin/src/constants/fair/constant.ts
+++ b/apps/admin/src/constants/fair/constant.ts
@@ -7,3 +7,12 @@ export const FAIR_STATUS: Record<FairStatus, string> = {
   APPLICATION_NOT_STARTED: '신청 시작 전',
   APPLICATION_EARLY_CLOSED: '조기 마감',
 } as const;
+
+export const FAIR_TAP_STATUS: Record<string, string[]> = {
+  '진행 중인 신청': [
+    'APPLICATION_IN_PROGRESS',
+    'APPLICATION_NOT_STARTED',
+    'APPLICATION_ENDED',
+  ],
+  '마감된 신청': ['CLOSED', 'APPLICATION_EARLY_CLOSED'],
+};

--- a/apps/admin/src/constants/fair/constant.ts
+++ b/apps/admin/src/constants/fair/constant.ts
@@ -1,0 +1,9 @@
+import { FairStatus } from '@/types/fair/client';
+
+export const FAIR_STATUS: Record<FairStatus, string> = {
+  APPLICATION_ENDED: '신청 종료',
+  CLOSED: '마감',
+  APPLICATION_IN_PROGRESS: '신청 가능',
+  APPLICATION_NOT_STARTED: '신청 시작 전',
+  APPLICATION_EARLY_CLOSED: '조기 마감',
+} as const;

--- a/apps/admin/src/services/fair/api.ts
+++ b/apps/admin/src/services/fair/api.ts
@@ -1,0 +1,8 @@
+import { maru } from '@/apis/instance/instance';
+import { GetFairListRes } from '@/types/fair/remote';
+
+export const getFairList = async () => {
+  const { data } = await maru.get<GetFairListRes>(`/fairs`);
+
+  return data;
+};

--- a/apps/admin/src/services/fair/api.ts
+++ b/apps/admin/src/services/fair/api.ts
@@ -13,3 +13,12 @@ export const getFairDetail = async (id: number) => {
 
   return data;
 };
+
+export const getFairExportExcel = async (id: number) => {
+  const { data } = await maru.get(`/fair/${id}/export`, {
+    ...authorization(),
+    responseType: 'blob',
+  });
+
+  return data;
+};

--- a/apps/admin/src/services/fair/api.ts
+++ b/apps/admin/src/services/fair/api.ts
@@ -1,8 +1,15 @@
 import { maru } from '@/apis/instance/instance';
-import { GetFairListRes } from '@/types/fair/remote';
+import { authorization } from '@/apis/token';
+import { GetFairListRes, GetFairDetailRes } from '@/types/fair/remote';
 
 export const getFairList = async () => {
   const { data } = await maru.get<GetFairListRes>(`/fairs`);
+
+  return data;
+};
+
+export const getFairDetail = async (id: number) => {
+  const { data } = await maru.get<GetFairDetailRes>(`/fairs/${id}`, authorization());
 
   return data;
 };

--- a/apps/admin/src/services/fair/queries.ts
+++ b/apps/admin/src/services/fair/queries.ts
@@ -17,5 +17,5 @@ export const useFairDetailQuery = (id: number) => {
     queryFn: () => getFairDetail(id),
   });
 
-  return { data: data, ...restQuery };
+  return { data: data?.data, ...restQuery };
 };

--- a/apps/admin/src/services/fair/queries.ts
+++ b/apps/admin/src/services/fair/queries.ts
@@ -1,6 +1,6 @@
 import { KEY } from '@/constants/common/constant';
 import { useQuery } from '@tanstack/react-query';
-import { getFairDetail, getFairList } from './api';
+import { getFairDetail, getFairExportExcel, getFairList } from './api';
 
 export const useFairListQuery = () => {
   const { data, ...restQuery } = useQuery({
@@ -18,4 +18,13 @@ export const useFairDetailQuery = (id: number) => {
   });
 
   return { data: data?.data, ...restQuery };
+};
+
+export const useFairExportExcelQuery = (id: number) => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.FAIR_EXPORT_EXCEL, id],
+    queryFn: () => getFairExportExcel(id),
+  });
+
+  return { data: data, ...restQuery };
 };

--- a/apps/admin/src/services/fair/queries.ts
+++ b/apps/admin/src/services/fair/queries.ts
@@ -13,7 +13,7 @@ export const useFairListQuery = () => {
 
 export const useFairDetailQuery = (id: number) => {
   const { data, ...restQuery } = useQuery({
-    queryKey: [KEY.FAIR_DETAIL],
+    queryKey: [KEY.FAIR_DETAIL, id],
     queryFn: () => getFairDetail(id),
   });
 

--- a/apps/admin/src/services/fair/queries.ts
+++ b/apps/admin/src/services/fair/queries.ts
@@ -1,6 +1,6 @@
 import { KEY } from '@/constants/common/constant';
 import { useQuery } from '@tanstack/react-query';
-import { getFairList } from './api';
+import { getFairDetail, getFairList } from './api';
 
 export const useFairListQuery = () => {
   const { data, ...restQuery } = useQuery({
@@ -9,4 +9,13 @@ export const useFairListQuery = () => {
   });
 
   return { data: data?.dataList, ...restQuery };
+};
+
+export const useFairDetailQuery = (id: number) => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.FAIR_DETAIL],
+    queryFn: () => getFairDetail(id),
+  });
+
+  return { data: data, ...restQuery };
 };

--- a/apps/admin/src/services/fair/queries.ts
+++ b/apps/admin/src/services/fair/queries.ts
@@ -1,0 +1,12 @@
+import { KEY } from '@/constants/common/constant';
+import { useQuery } from '@tanstack/react-query';
+import { getFairList } from './api';
+
+export const useFairListQuery = () => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.FAIR_LIST],
+    queryFn: getFairList,
+  });
+
+  return { data: data?.dataList, ...restQuery };
+};

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -1,5 +1,7 @@
 export type FairType = 'STUDENT_AND_PARENT' | 'TEACHER';
 
+export type StatusType = 'open' | 'closed' | 'full';
+
 export type FairStatus =
   | 'APPLICATION_ENDED'
   | 'CLOSED'

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -1,11 +1,11 @@
 export type FairType = 'STUDENT_AND_PARENT' | 'TEACHER';
 
 export type FairStatus =
-  | 'APPLICATION_ENDED' // 신청 종료됨
-  | 'CLOSED' // 종료됨
-  | 'APPLICATION_IN_PROGRESS' // 신청 진행 중
-  | 'APPLICATION_NOT_STARTED' // 신청 진행 시작 전
-  | 'APPLICATION_EARLY_CLOSED'; // 신청 조기 종료
+  | 'APPLICATION_ENDED'
+  | 'CLOSED'
+  | 'APPLICATION_IN_PROGRESS'
+  | 'APPLICATION_NOT_STARTED'
+  | 'APPLICATION_EARLY_CLOSED';
 
 export interface Fair {
   start: string;
@@ -17,6 +17,7 @@ export interface Fair {
 }
 
 export interface FairData {
+  id: number;
   start: string;
   place: String;
   applicationStartDate: String | null;

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -24,3 +24,21 @@ export interface FairData {
   applicationEndDate: string;
   status: FairStatus;
 }
+
+export interface AttendeeData {
+  schoolName: string;
+  name: string;
+  type: string;
+  phoneNumber: string;
+  headcount: number;
+  question: string;
+}
+
+export interface FairDetailData {
+  start: string;
+  place: string;
+  applicationStartDate: string;
+  applicationEndDate: string;
+  status: FairStatus;
+  attendeeList: AttendeeData[];
+}

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -20,7 +20,7 @@ export interface FairData {
   id: number;
   start: string;
   place: string;
-  applicationStartDate: string | null;
-  applicationEndDate: string | null;
+  applicationStartDate: string;
+  applicationEndDate: string;
   status: FairStatus;
 }

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -1,0 +1,25 @@
+export type FairType = 'STUDENT_AND_PARENT' | 'TEACHER';
+
+export type FairStatus =
+  | 'APPLICATION_ENDED' // 신청 종료됨
+  | 'CLOSED' // 종료됨
+  | 'APPLICATION_IN_PROGRESS' // 신청 진행 중
+  | 'APPLICATION_NOT_STARTED' // 신청 진행 시작 전
+  | 'APPLICATION_EARLY_CLOSED'; // 신청 조기 종료
+
+export interface Fair {
+  start: string;
+  capacity: number;
+  place: String;
+  type: FairType;
+  applicationStartDate: String | null;
+  applicationEndDate: String | null;
+}
+
+export interface FairData {
+  start: string;
+  place: String;
+  applicationStartDate: String | null;
+  applicationEndDate: String | null;
+  status: FairStatus;
+}

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -10,17 +10,17 @@ export type FairStatus =
 export interface Fair {
   start: string;
   capacity: number;
-  place: String;
+  place: string;
   type: FairType;
-  applicationStartDate: String | null;
-  applicationEndDate: String | null;
+  applicationStartDate: string | null;
+  applicationEndDate: string | null;
 }
 
 export interface FairData {
   id: number;
   start: string;
-  place: String;
-  applicationStartDate: String | null;
-  applicationEndDate: String | null;
+  place: string;
+  applicationStartDate: string | null;
+  applicationEndDate: string | null;
   status: FairStatus;
 }

--- a/apps/admin/src/types/fair/remote.ts
+++ b/apps/admin/src/types/fair/remote.ts
@@ -1,0 +1,5 @@
+import { FairData } from './client';
+
+export interface GetFairListRes {
+  dataList: FairData[];
+}

--- a/apps/admin/src/types/fair/remote.ts
+++ b/apps/admin/src/types/fair/remote.ts
@@ -1,5 +1,9 @@
-import { FairData } from './client';
+import { FairData, FairDetailData } from './client';
 
 export interface GetFairListRes {
   dataList: FairData[];
+}
+
+export interface GetFairDetailRes {
+  data: FairDetailData;
 }

--- a/apps/admin/src/utils/functions/formatDate.ts
+++ b/apps/admin/src/utils/functions/formatDate.ts
@@ -1,0 +1,64 @@
+const formatDate = {
+  normalizeDate: (dateString: string): string => {
+    let normalizedDate = dateString;
+
+    if (dateString.includes('T')) {
+      normalizedDate = new Date(dateString).toISOString();
+    }
+
+    if (dateString.includes('-') && !dateString.includes('T')) {
+      normalizedDate = new Date(dateString + 'T00:00:00').toISOString();
+    }
+
+    if (dateString.includes('.') && !dateString.includes('T')) {
+      const reformatted = dateString.replace(/\./g, '-');
+      normalizedDate = new Date(reformatted + 'T00:00:00').toISOString();
+    }
+
+    return normalizedDate;
+  },
+
+  toFullDateTime: (dateString: string) => {
+    const date = new Date(formatDate.normalizeDate(dateString));
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+
+    return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+  },
+
+  toDayAndDateTime: (dateString: string) => {
+    const date = new Date(formatDate.normalizeDate(dateString));
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+
+    const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+    const dayOfWeek = dayNames[date.getDay()];
+
+    return `${month}월 ${day}일 (${dayOfWeek}) ${hours}:${minutes}`;
+  },
+
+  toDashedDate: (dateString: string) => {
+    const date = new Date(formatDate.normalizeDate(dateString));
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+
+    return `${year}.${month}.${day}`;
+  },
+
+  toDotDate: (dateString: string) => {
+    const date = new Date(formatDate.normalizeDate(dateString));
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+
+    return `${year}.${month}.${day}`;
+  },
+};
+
+export default formatDate;

--- a/apps/admin/src/utils/functions/formatPhoneNumber.ts
+++ b/apps/admin/src/utils/functions/formatPhoneNumber.ts
@@ -1,0 +1,5 @@
+const formatPhoneNumber = (phoneNumber: string) => {
+  return phoneNumber.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+};
+
+export default formatPhoneNumber;

--- a/apps/admin/src/utils/index.ts
+++ b/apps/admin/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as resizeTextarea } from './functions/resizeTextarea';
 export { default as formatDate } from './functions/formatDate';
+export { default as formatPhoneNumber } from './functions/formatPhoneNumber';

--- a/apps/admin/src/utils/index.ts
+++ b/apps/admin/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as resizeTextarea } from './functions/resizeTextarea';
+export { default as formatDate } from './functions/formatDate';

--- a/packages/ui/src/Text/Text.tsx
+++ b/packages/ui/src/Text/Text.tsx
@@ -45,6 +45,7 @@ const StyledText = styled.span<{ fontType: Font; ellipsis: boolean }>`
   ${(props) =>
     props.ellipsis &&
     css`
+      display: inline-block;
       overflow: hidden;
       text-overflow: ellipsis;
     `}


### PR DESCRIPTION
## 📄 Summary

> 입학 설명회 페이지 조회와 상세 조회를 개발했습니다.

<br>

## 🔨 Tasks

- 입학전형 설명회 관리 페이지 추가
- 입학설명회 개별(상세) 조회(신청자 조회) 페이지 추가
- 신청자 엑셀로 다운로드 기능 추가
- 신청자 질문 모달 추가
- API 연동

<br>

## 🙋🏻 More
입학전형 설명회 생성(추가) 페이지는 2025학년도 기준 2학년 학생들의 과제로 내줄 예정이여서 구현하지 않았습니다.