### PR TITLE
feat(admin): 원서 관리 페이지 원서 조회 기능 추가

### DIFF
--- a/apps/admin/src/app/form/form.hooks.ts
+++ b/apps/admin/src/app/form/form.hooks.ts
@@ -1,0 +1,29 @@
+import { useFormListSortingTypeStore, useFormListTypeStore } from '@/store/form/formType';
+import { FormListSortingType } from '@/types/form/client';
+
+export const useFormPageState = () => {
+  const [formListType, setFormListType] = useFormListTypeStore();
+  const [formListSortingType, setFormListSortingType] = useFormListSortingTypeStore();
+
+  const handleCriteriaChange = (value: string, key: string) => {
+    setFormListType('정렬');
+    if (value === 'RESET') {
+      setFormListSortingType((prev) => ({ ...prev, [key]: null }));
+    } else {
+      setFormListSortingType((prev) => ({ ...prev, [key]: value }));
+    }
+  };
+
+  const getCriteriaDropdownValue = (
+    key: keyof FormListSortingType,
+    category: Record<string, string>
+  ) => {
+    const value = formListSortingType[key];
+    return value ? category[value] : undefined;
+  };
+
+  return {
+    handleCriteriaChange,
+    getCriteriaDropdownValue,
+  };
+};

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -2,7 +2,14 @@
 
 import { FunctionDropdown } from '@/components/common';
 import FormTable from '@/components/form/FormTable/FormTable';
+import {
+  FORM_SORTING_CATEGORY,
+  FORM_STATUS_CATEGORY,
+  FORM_TYPE_CATEGORY,
+} from '@/constants/form/constant';
 import AppLayout from '@/layouts/AppLayout';
+import { useFormListSortingTypeStore, useFormListTypeStore } from '@/store/form/formType';
+import { FormStatus, FormType, FormSort } from '@/types/form/client';
 import {
   IconAdmission,
   IconCheckDocument,
@@ -16,6 +23,41 @@ import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
 
 const FormPage = () => {
+  const [formListType, setFormListType] = useFormListTypeStore();
+  const [formListSortingType, setFormListSortingType] = useFormListSortingTypeStore();
+
+  const handleSortStatus = (value: string) => {
+    console.log(value);
+    setFormListType('정렬');
+    if (value === 'RESET') {
+      setFormListSortingType((prev) => ({ ...prev, status: null }));
+    } else {
+      setFormListSortingType((prev) => ({ ...prev, status: value as FormStatus }));
+    }
+  };
+
+  const handleSortType = (value: string) => {
+    console.log(value);
+
+    setFormListType('정렬');
+    if (value === 'RESET') {
+      setFormListSortingType((prev) => ({ ...prev, type: null }));
+    } else {
+      setFormListSortingType((prev) => ({ ...prev, type: value as FormType }));
+    }
+  };
+
+  const handleSortForm = (value: string) => {
+    console.log(value);
+
+    setFormListType('정렬');
+    if (value === 'RESET') {
+      setFormListSortingType((prev) => ({ ...prev, sort: null }));
+    } else {
+      setFormListSortingType((prev) => ({ ...prev, sort: value as FormSort }));
+    }
+  };
+
   return (
     <AppLayout>
       <StyledFormPage>
@@ -36,11 +78,17 @@ const FormPage = () => {
                   { value: 'FIRST_PASSED', label: '1차 합격' },
                   { value: 'PASSED', label: '최종 합격' },
                   { value: 'REJECTED', label: '반려' },
+                  { value: 'ENTERED', label: '입학' },
                 ]}
                 size="SMALL"
                 width={160}
                 placeholder="상태 별"
-                onChange={() => {}}
+                onChange={handleSortStatus}
+                value={
+                  formListSortingType.status
+                    ? FORM_STATUS_CATEGORY[formListSortingType.status]
+                    : undefined
+                }
                 name="statusSort"
                 doubled={5}
               />
@@ -67,7 +115,12 @@ const FormPage = () => {
                 size="SMALL"
                 width={160}
                 placeholder="전형 별"
-                onChange={() => {}}
+                onChange={handleSortType}
+                value={
+                  formListSortingType.type
+                    ? FORM_TYPE_CATEGORY[formListSortingType.type]
+                    : undefined
+                }
                 name="typeSort"
                 doubled={5}
               />
@@ -81,7 +134,12 @@ const FormPage = () => {
                 size="SMALL"
                 width={160}
                 placeholder="최종 점수"
-                onChange={() => {}}
+                onChange={handleSortForm}
+                value={
+                  formListSortingType.sort
+                    ? FORM_SORTING_CATEGORY[formListSortingType.sort]
+                    : undefined
+                }
                 name="formSort"
               />
             </Row>

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -8,8 +8,6 @@ import {
   FORM_TYPE_CATEGORY,
 } from '@/constants/form/constant';
 import AppLayout from '@/layouts/AppLayout';
-import { useFormListSortingTypeStore, useFormListTypeStore } from '@/store/form/formType';
-import { FormStatus, FormType, FormSort } from '@/types/form/client';
 import {
   IconAdmission,
   IconCheckDocument,
@@ -21,37 +19,10 @@ import {
 import { Column, Dropdown, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
+import { useFormPageState } from './form.hooks';
 
 const FormPage = () => {
-  const [formListType, setFormListType] = useFormListTypeStore();
-  const [formListSortingType, setFormListSortingType] = useFormListSortingTypeStore();
-
-  const handleSortStatus = (value: string) => {
-    setFormListType('정렬');
-    if (value === 'RESET') {
-      setFormListSortingType((prev) => ({ ...prev, status: null }));
-    } else {
-      setFormListSortingType((prev) => ({ ...prev, status: value as FormStatus }));
-    }
-  };
-
-  const handleSortType = (value: string) => {
-    setFormListType('정렬');
-    if (value === 'RESET') {
-      setFormListSortingType((prev) => ({ ...prev, type: null }));
-    } else {
-      setFormListSortingType((prev) => ({ ...prev, type: value as FormType }));
-    }
-  };
-
-  const handleSortForm = (value: string) => {
-    setFormListType('정렬');
-    if (value === 'RESET') {
-      setFormListSortingType((prev) => ({ ...prev, sort: null }));
-    } else {
-      setFormListSortingType((prev) => ({ ...prev, sort: value as FormSort }));
-    }
-  };
+  const { handleCriteriaChange, getCriteriaDropdownValue } = useFormPageState();
 
   return (
     <AppLayout>
@@ -78,13 +49,9 @@ const FormPage = () => {
                 size="SMALL"
                 width={160}
                 placeholder="상태 별"
-                onChange={handleSortStatus}
-                value={
-                  formListSortingType.status
-                    ? FORM_STATUS_CATEGORY[formListSortingType.status]
-                    : undefined
-                }
-                name="statusSort"
+                onChange={handleCriteriaChange}
+                value={getCriteriaDropdownValue('status', FORM_STATUS_CATEGORY)}
+                name="status"
                 doubled={5}
               />
               <Dropdown
@@ -110,13 +77,9 @@ const FormPage = () => {
                 size="SMALL"
                 width={160}
                 placeholder="전형 별"
-                onChange={handleSortType}
-                value={
-                  formListSortingType.type
-                    ? FORM_TYPE_CATEGORY[formListSortingType.type]
-                    : undefined
-                }
-                name="typeSort"
+                onChange={handleCriteriaChange}
+                value={getCriteriaDropdownValue('type', FORM_TYPE_CATEGORY)}
+                name="type"
                 doubled={5}
               />
               <Dropdown
@@ -129,13 +92,9 @@ const FormPage = () => {
                 size="SMALL"
                 width={160}
                 placeholder="최종 점수"
-                onChange={handleSortForm}
-                value={
-                  formListSortingType.sort
-                    ? FORM_SORTING_CATEGORY[formListSortingType.sort]
-                    : undefined
-                }
-                name="formSort"
+                onChange={handleCriteriaChange}
+                value={getCriteriaDropdownValue('sort', FORM_SORTING_CATEGORY)}
+                name="sort"
               />
             </Row>
             <FunctionDropdown

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -27,7 +27,6 @@ const FormPage = () => {
   const [formListSortingType, setFormListSortingType] = useFormListSortingTypeStore();
 
   const handleSortStatus = (value: string) => {
-    console.log(value);
     setFormListType('정렬');
     if (value === 'RESET') {
       setFormListSortingType((prev) => ({ ...prev, status: null }));
@@ -37,8 +36,6 @@ const FormPage = () => {
   };
 
   const handleSortType = (value: string) => {
-    console.log(value);
-
     setFormListType('정렬');
     if (value === 'RESET') {
       setFormListSortingType((prev) => ({ ...prev, type: null }));
@@ -48,8 +45,6 @@ const FormPage = () => {
   };
 
   const handleSortForm = (value: string) => {
-    console.log(value);
-
     setFormListType('정렬');
     if (value === 'RESET') {
       setFormListSortingType((prev) => ({ ...prev, sort: null }));

--- a/apps/admin/src/components/form/FormTable/FormTable.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTable.tsx
@@ -1,32 +1,16 @@
 import { Column } from '@maru/ui';
-
 import FormTableHeader from './FormTableHeader/FormTableHeader';
 import FormTableItem from './FormTableItem/FormTableItem';
-
-const fromList = [
-  {
-    id: 1,
-    examinationNumber: 1001,
-    name: '이민준',
-    birthday: '2007-09-19',
-    graduationType: 'EXPECTED',
-    school: '재송중학교',
-    status: 'SUBMITTED',
-    type: 'REGULAR',
-    isChangedToRegular: false,
-    totalScore: null,
-    hasDocument: false,
-    firstRoundPassed: null,
-    secondRoundPassed: null,
-  },
-];
+import { useFormListQuery } from '@/services/form/queries';
 
 const FormTable = () => {
+  const { data: formList } = useFormListQuery();
+
   return (
     <Column gap={12}>
       <FormTableHeader />
-      {fromList &&
-        fromList.map((item) => (
+      {formList &&
+        formList.map((item) => (
           <FormTableItem
             id={item.id}
             examinationNumber={item.examinationNumber}

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -1,6 +1,8 @@
 export const KEY = {
   ADMIN: 'useAdmin',
 
+  FORM_LIST: 'useFormList',
+
   FAIR_LIST: 'useFairList',
   FAIR_DETAIL: 'useFairDetail',
   FAIR_EXPORT_EXCEL: 'useFairExportExcel',

--- a/apps/admin/src/constants/form/constant.ts
+++ b/apps/admin/src/constants/form/constant.ts
@@ -1,0 +1,37 @@
+import { FormSort, FormStatus, FormType } from '@/types/form/client';
+
+export const FORM_STATUS_CATEGORY: Record<FormStatus, string> = {
+  APPROVED: '접수',
+  FIRST_FAILED: '1차 불합격',
+  FAILED: '불합격',
+  FINAL_SUBMITTED: '최종 제출',
+  SUBMITTED: '제출',
+  RECEIVED: '승인',
+  NO_SHOW: '불참',
+  FIRST_PASSED: '1차 합격',
+  PASSED: '최종 합격',
+  REJECTED: '반려',
+  ENTERED: '입학',
+} as const;
+
+export const FORM_TYPE_CATEGORY: Record<FormType, string> = {
+  REGULAR: '일반전형',
+  MEISTER_TALENT: '마이스터인재전형',
+  NATIONAL_BASIC_LIVING: '국가기초생활수급권자',
+  NATIONAL_VETERANS_EDUCATION: '국가보훈대상자 중 교육지원대상자녀',
+  NEAR_POVERTY: '차상위계층',
+  NATIONAL_VETERANS: '국가보훈자녀',
+  ONE_PARENT: '한부모가정',
+  FROM_NORTH_KOREA: '북한이탈주민',
+  MULTICULTURAL: '다문화가정',
+  TEEN_HOUSEHOLDER: '소년소녀가장',
+  MULTI_CHILDREN: '다자녀가정자녀',
+  FARMING_AND_FISHING: '농어촌지역출신자',
+  SPECIAL_ADMISSION: '특례입학대상자',
+} as const;
+
+export const FORM_SORTING_CATEGORY: Record<FormSort, string> = {
+  'total-score-desc': '최종 점수 높은 순',
+  'total-score-asc': '최종 점수 낮은 순',
+  'form-id': '접수순',
+} as const;

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -1,0 +1,9 @@
+import { maru } from '@/apis/instance/instance';
+import { authorization } from '@/apis/token';
+import { GetFormListRes } from '@/types/form/remote';
+
+export const getFormList = async () => {
+  const { data } = await maru.get<GetFormListRes>('/form', authorization());
+
+  return data;
+};

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -1,9 +1,28 @@
 import { maru } from '@/apis/instance/instance';
 import { authorization } from '@/apis/token';
+import { FormListSortingType, FormListType } from '@/types/form/client';
 import { GetFormListRes } from '@/types/form/remote';
 
-export const getFormList = async () => {
-  const { data } = await maru.get<GetFormListRes>('/form', authorization());
+export const getFormList = async (
+  formListType: FormListType,
+  formListSortingType?: FormListSortingType
+) => {
+  let url = '/form';
+
+  if (formListType === '검토해야 하는 원서 모아보기') {
+    url = '/form/review';
+  } else if (formListType === '정렬' && formListSortingType) {
+    const params = new URLSearchParams();
+
+    if (formListSortingType.status) params.append('status', formListSortingType.status);
+    if (formListSortingType.type) params.append('type', formListSortingType.type);
+    if (formListSortingType.sort) params.append('sort', formListSortingType.sort);
+
+    const queryString = params.toString();
+    if (queryString) url += `?${queryString}`;
+  }
+
+  const { data } = await maru.get<GetFormListRes>(url, authorization());
 
   return data;
 };

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -1,11 +1,18 @@
 import { KEY } from '@/constants/common/constant';
 import { getFormList } from './api';
 import { useQuery } from '@tanstack/react-query';
+import {
+  useFormListSortingTypeValueStore,
+  useFormListTypeValueStore,
+} from '@/store/form/formType';
 
 export const useFormListQuery = () => {
+  const formListType = useFormListTypeValueStore();
+  const formListSortingType = useFormListSortingTypeValueStore();
+
   const { data, ...restQuery } = useQuery({
-    queryKey: [KEY.FORM_LIST],
-    queryFn: getFormList,
+    queryKey: [KEY.FORM_LIST, formListType, formListSortingType],
+    queryFn: () => getFormList(formListType, formListSortingType),
   });
 
   return { data: data?.dataList, ...restQuery };

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -1,0 +1,12 @@
+import { KEY } from '@/constants/common/constant';
+import { getFormList } from './api';
+import { useQuery } from '@tanstack/react-query';
+
+export const useFormListQuery = () => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.FORM_LIST],
+    queryFn: getFormList,
+  });
+
+  return { data: data?.dataList, ...restQuery };
+};

--- a/apps/admin/src/store/form/formType.ts
+++ b/apps/admin/src/store/form/formType.ts
@@ -1,0 +1,27 @@
+import type { FormListType, FormListSortingType } from '@/types/form/client';
+import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
+const formListTypeAtomState = atom<FormListType>({
+  key: 'form-type',
+  default: '모두 보기',
+});
+
+const formListSortingTypeAtomState = atom<FormListSortingType>({
+  key: 'form-sort-type',
+  default: {
+    status: null,
+    type: null,
+    sort: null,
+  },
+});
+
+export const useFormListTypeStore = () => useRecoilState(formListTypeAtomState);
+export const useFormListTypeValueStore = () => useRecoilValue(formListTypeAtomState);
+export const useSetFormListTypeStore = () => useSetRecoilState(formListTypeAtomState);
+
+export const useFormListSortingTypeStore = () =>
+  useRecoilState(formListSortingTypeAtomState);
+export const useFormListSortingTypeValueStore = () =>
+  useRecoilValue(formListSortingTypeAtomState);
+export const useSetFormListSortingTypeStore = () =>
+  useSetRecoilState(formListSortingTypeAtomState);

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -54,3 +54,13 @@ export interface Form {
   firstRoundPassed: boolean | null;
   secondRoundPassed: boolean | null;
 }
+
+export type FormListType = '모두 보기' | '검토해야 하는 원서 모아보기' | '정렬';
+
+export type FormSort = 'total-score-asc' | 'total-score-desc' | 'form-id';
+
+export interface FormListSortingType {
+  status: FormStatus | null;
+  type: FormCategory | null;
+  sort: FormSort | null;
+}

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -26,17 +26,6 @@ export type FormType =
   | 'NATIONAL_VETERANS'
   | 'TEEN_HOUSEHOLDER';
 
-export type FormCategory =
-  | 'NATIONAL_VETERANS_EDUCATION'
-  | 'REGULAR'
-  | 'SOCIETY_DIVERSITY'
-  | 'MEISTER_TALENT'
-  | 'EQUAL_OPPORTUNITY'
-  | 'SOCIAL_INTEGRATION'
-  | 'SUPERNUMERARY'
-  | 'SPECIAL_ADMISSION'
-  | 'SPECIAL';
-
 export type GraduationType = 'EXPECTED' | 'GRADUATED' | 'QUALIFICATION_EXAMINATION';
 
 export interface Form {
@@ -61,6 +50,6 @@ export type FormSort = 'total-score-asc' | 'total-score-desc' | 'form-id';
 
 export interface FormListSortingType {
   status: FormStatus | null;
-  type: FormCategory | null;
+  type: FormType | null;
   sort: FormSort | null;
 }

--- a/apps/admin/src/types/form/remote.ts
+++ b/apps/admin/src/types/form/remote.ts
@@ -1,0 +1,5 @@
+import { Form } from './client';
+
+export interface GetFormListRes {
+  dataList: Form[];
+}


### PR DESCRIPTION
## 📄 Summary

> 어드민 원서 관리 페이지의 원서 리스트 조회 기능과 원서 상태, 전형, 정렬 별 조회 기능을 추가했습니다. 

<br>

## 🔨 Tasks

- 원서 리스트 조회 기능 추가
- 원서 상태, 전형, 정렬 별 조회 기능 추가
- API 연동

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/465f1eb0-dc49-4a97-8804-13d12ec2ef12)