### PR TITLE
feat(admin): 공지사항 fileNameList가 null 인 상태 추가

### DIFF
--- a/apps/admin/src/components/notice/NoticeCreate/NoticeCreate.hooks.ts
+++ b/apps/admin/src/components/notice/NoticeCreate/NoticeCreate.hooks.ts
@@ -37,7 +37,7 @@ export const useNoticeCreateData = () => {
   };
 };
 
-export const useNoticeCreateAction = (noticeData: PostNoticeReq) => {
+export const useNoticeCreateAction = (noticeData: NoticeInput) => {
   const { postNoticeMutate } = usePostNoticeMutation();
   const { noticeFileUrlMutate } = useNoticeFileUrlMutation();
   const [fileData, setFileData] = useNoticeFileStore();

--- a/apps/admin/src/components/notice/NoticeCreate/NoticeCreate.hooks.ts
+++ b/apps/admin/src/components/notice/NoticeCreate/NoticeCreate.hooks.ts
@@ -43,7 +43,7 @@ export const useNoticeCreateAction = (noticeData: PostNoticeReq) => {
   const [fileData, setFileData] = useNoticeFileStore();
 
   const handleNoticeCreateButtonClick = async () => {
-    const fileNameList = noticeData.fileNameList ?? [];
+    const fileNameList = noticeData.fileNameList?.length ? noticeData.fileNameList : null;
 
     if (fileData?.length) {
       await noticeFileUrlMutate(fileData);


### PR DESCRIPTION
## 📄 Summary

> 공지사항 생성 시 fileNameList의 length가 0이면 null로 보내야 하지만, 빈 배열로 보내고 있어 오류가 납니다. 
그래서 빈배열 일시 null로 보내도록 수정하였습니다.

<br>

## 🔨 Tasks

- fileNameList가 [] 빈 배열 일시 null로 처리

<br>

## 🙋🏻 More