### PR TITLE
fix(user): 스키마 별 trim으로 공백만 들어가면 에러 처리

### DIFF
--- a/apps/user/src/schemas/ApplicantSchema.ts
+++ b/apps/user/src/schemas/ApplicantSchema.ts
@@ -3,12 +3,14 @@ import { z } from 'zod';
 export const ApplicantSchema = z.object({
   name: z
     .string()
+    .trim()
     .nonempty('이름을 입력해 주세요.')
     .min(2, '이름은 2자 이상이어야 합니다.')
     .max(20, '이름은 20자 이하이어야 합니다.'),
   birthday: z.string().length(10, '생년월일을 정확히 입력해주세요.'),
   phoneNumber: z
     .string()
+    .trim()
     .nonempty('전화번호를 입력해주세요.')
     .regex(/^\d{11}$/, '전화번호는 11자리를 입력해주세요.'),
 });

--- a/apps/user/src/schemas/EducationSchema.ts
+++ b/apps/user/src/schemas/EducationSchema.ts
@@ -4,6 +4,7 @@ const qualificationSchema = z.object({
   graduationType: z.literal('QUALIFICATION_EXAMINATION'),
   graduationYear: z
     .string()
+    .trim()
     .nonempty('합격 연도를 입력해주세요.')
     .regex(/^\d{4}$/, '합격 연도를 입력해주세요.'),
 });
@@ -12,23 +13,28 @@ const schoolGraduateSchema = z.object({
   graduationType: z.enum(['EXPECTED', 'GRADUATED']),
   schoolName: z
     .string()
+    .trim()
     .nonempty('출신 학교를 입력해주세요.')
     .max(30, '출신 학교를 입력해주세요.'),
   graduationYear: z
     .string()
+    .trim()
     .nonempty('졸업 연도를 입력해주세요.')
     .regex(/^\d{4}$/, '졸업 연도를 입력해주세요.'),
   teacherPhoneNumber: z
     .string()
+    .trim()
     .min(10, '10자 이상 입력해주세요.')
     .max(20, '20자 이하로 입력해주세요.')
     .nonempty('전화번호를 입력해주세요.'),
   teacherName: z
     .string()
+    .trim()
     .min(2, '작성 교사 이름을 입력해주세요.')
     .nonempty('작성 교사 이름을 입력해주세요.'),
   teacherMobilePhoneNumber: z
     .string()
+    .trim()
     .regex(/^\d{11}$/, '11자리를 입력해주세요.')
     .nonempty('전화번호를 입력해주세요.'),
 });

--- a/apps/user/src/schemas/GuardianSchema.ts
+++ b/apps/user/src/schemas/GuardianSchema.ts
@@ -3,17 +3,24 @@ import { z } from 'zod';
 export const GuardianSchema = z.object({
   name: z
     .string()
+    .trim()
     .nonempty('이름을 입력해 주세요.')
     .min(2, '이름은 2자 이상이어야 합니다.')
     .max(20, '이름은 20자 이하이어야 합니다.'),
   phoneNumber: z
     .string()
+    .trim()
     .nonempty('전화번호를 입력해주세요.')
     .regex(/^\d{11}$/, '전화번호는 11자리를 입력해주세요.'),
-  relation: z.string().nonempty('올바른 값을 입력해주세요'),
-  address: z.string().nonempty('주소를 입력해주세요.').max(100, '주소를 입력해주세요.'),
+  relation: z.string().trim().nonempty('올바른 값을 입력해주세요'),
+  address: z
+    .string()
+    .trim()
+    .nonempty('주소를 입력해주세요.')
+    .max(100, '주소를 입력해주세요.'),
   detailAddress: z
     .string()
+    .trim()
     .nonempty('알맞은 상세 주소를 입력해 주세요.')
     .max(100, '알맞은 상세 주소를 입력해 주세요.'),
 });


### PR DESCRIPTION
## 📄 Summary

> 스키마 별로 nonempty, min, max등 조건이나 없을때는 유효성 검사를 해주지만 공백일 경우에는 유효성 검사를 진행하지 않고 있었습니다. trim을 사용해서 공백만 있을 경우는 에러 처리가 가능하도록 수정했습니다.

<br>

## 🔨 Tasks

- 각 스키마 수정

<br>

## 🙋🏻 More
