### PR TITLE
fix(user): 반려시 원서 재체출하도록 수정

### DIFF
--- a/apps/user/src/app/form/DraftCompleted/DraftCompleted.hook.ts
+++ b/apps/user/src/app/form/DraftCompleted/DraftCompleted.hook.ts
@@ -1,5 +1,9 @@
 import { Storage } from '@/apis/storage/storage';
-import { useSubmitDraftFormMutation } from '@/services/form/mutations';
+import {
+  useCorrectionFormMutation,
+  useSubmitDraftFormMutation,
+} from '@/services/form/mutations';
+import { useFormStatusQuery } from '@/services/form/queries';
 import { useFormValueStore, useSetFormStepStore } from '@/stores';
 import type { Form } from '@/types/form/client';
 import { useEffect, useState } from 'react';
@@ -8,13 +12,19 @@ export const useCTAButton = () => {
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const { submitDraftFormMutate } = useSubmitDraftFormMutation(form);
+  const { correctionFormMutate } = useCorrectionFormMutation();
+  const { data: statusData } = useFormStatusQuery();
 
   const handleCheckAgainForm = () => {
     setFormStep('지원자정보');
   };
 
   const handleSubmitDraftForm = () => {
-    submitDraftFormMutate();
+    if (statusData?.status === 'REJECTED') {
+      correctionFormMutate(form);
+    } else {
+      submitDraftFormMutate();
+    }
   };
 
   return { handleCheckAgainForm, handleSubmitDraftForm };

--- a/apps/user/src/services/form/api.ts
+++ b/apps/user/src/services/form/api.ts
@@ -126,3 +126,9 @@ export const getUploadProfile = async (fileUrl: string) => {
 
   return URL.createObjectURL(data);
 };
+
+export const putFormCorrection = async (formData: Form) => {
+  const { data } = await maru.put('/forms', formData, authorization());
+
+  return data;
+};

--- a/apps/user/src/services/form/mutations.ts
+++ b/apps/user/src/services/form/mutations.ts
@@ -7,6 +7,7 @@ import {
   postSaveForm,
   postSubmitDraftFrom,
   postUploadProfileImage,
+  putFormCorrection,
   putProfileUpoload,
   putUploadForm,
 } from './api';
@@ -132,4 +133,17 @@ export const useRefreshProfileImageMutation = () => {
   });
 
   return mutation;
+};
+
+export const useCorrectionFormMutation = () => {
+  const { handleError } = useApiError();
+  const setFormStep = useSetFormStepStore();
+
+  const { mutate: correctionFormMutate, ...restMutation } = useMutation({
+    mutationFn: (formData: Form) => putFormCorrection(formData),
+    onSuccess: () => setFormStep('초안제출완료'),
+    onError: handleError,
+  });
+
+  return { correctionFormMutate, ...restMutation };
 };


### PR DESCRIPTION
## 📄 Summary

> 원서가 반려되면 원서를 재체출할 수 있도록 수정할 수 있도록 수정했습니다.

<br>

## 🔨 Tasks

- 원서 수정 API 연동
- 반려시 초안 제출 호출 함수 변경

<br>

## 🙋🏻 More
