### PR TITLE
feat(admin): 2차 합격 여부 변경하기 기능 추가

### DIFF
--- a/apps/admin/src/app/form/form.hooks.ts
+++ b/apps/admin/src/app/form/form.hooks.ts
@@ -1,4 +1,7 @@
+import { useEditSecondRoundResultMutation } from '@/services/form/mutations';
 import { useFormListSortingTypeStore, useFormListTypeStore } from '@/store/form/formType';
+import { useIsSecondRoundResultEditingStore } from '@/store/form/isSecondRoundResultEditing';
+import { useSecondRoundResultValueStore } from '@/store/form/secondRoundResult';
 import type { FormListSortingType } from '@/types/form/client';
 
 export const useFormPageState = () => {
@@ -31,5 +34,38 @@ export const useFormPageState = () => {
     handleFormListTypeReview,
     handleFormListTypeAll,
     getCriteriaDropdownValue,
+  };
+};
+
+export const useEditSecondRoundResultActions = () => {
+  const [isSecondRoundResultEditing, setIsSecondRoundResultEditing] =
+    useIsSecondRoundResultEditingStore();
+
+  const setIsSecondRoundResultEditingTrue = () => setIsSecondRoundResultEditing(true);
+  const setIsSecondRoundResultEditingFalse = () => {
+    setIsSecondRoundResultEditing(false);
+  };
+
+  const secondRoundResult = useSecondRoundResultValueStore();
+  const secondRoundResultData = {
+    formList: Object.entries(secondRoundResult).map(([formId, passStatus]) => {
+      return {
+        formId: Number(formId),
+        pass: passStatus === '미정' ? null : passStatus === '합격',
+      };
+    }),
+  };
+  const { editSecondRoundResult } =
+    useEditSecondRoundResultMutation(secondRoundResultData);
+
+  const handleSecondRoundResultEditCompleteButtonClick = () => {
+    editSecondRoundResult();
+  };
+
+  return {
+    isSecondRoundResultEditing,
+    setIsSecondRoundResultEditingTrue,
+    setIsSecondRoundResultEditingFalse,
+    handleSecondRoundResultEditCompleteButtonClick,
   };
 };

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -18,13 +18,14 @@ import {
   IconPrint,
   IconUpload,
 } from '@maru/icon';
-import { Column, Dropdown, Row, Text } from '@maru/ui';
+import { Button, Column, Dropdown, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
 import { useFormPageState } from './form.hooks';
 import { color } from '@maru/design-system';
 import { useOverlay } from '@toss/use-overlay';
 import SecondScoreUploadModal from '@/components/form/SecondScoreUploadModal/SecondScoreUploadModal';
+import { useIsSecondRoundResultEditingStore } from '@/store/form/isSecondRoundResultEditing';
 
 const FormPage = () => {
   const {
@@ -34,6 +35,14 @@ const FormPage = () => {
     handleFormListTypeAll,
     getCriteriaDropdownValue,
   } = useFormPageState();
+
+  const [isSecondRoundResultEditing, setIsSecondRoundResultEditing] =
+    useIsSecondRoundResultEditingStore();
+
+  const setIsSecondRoundResultEditingTrue = () => setIsSecondRoundResultEditing(true);
+  const setIsSecondRoundResultEditingFalse = () => {
+    setIsSecondRoundResultEditing(false);
+  };
 
   const overlay = useOverlay();
 
@@ -138,52 +147,67 @@ const FormPage = () => {
                   />
                 </ReviewFilterBox>
               ) : null}
-              <FunctionDropdown
-                data={[
-                  {
-                    icon: <IconCheckDocument width={24} height={24} />,
-                    label: '검토해야하는 원서 모아보기',
-                    value: 'review_applications',
-                    onClick: handleFormListTypeReview,
-                  },
-                  {
-                    icon: <IconEditDocument width={24} height={24} />,
-                    label: '2차 전형 점수 입력하기',
-                    value: 'input_second_round_scores',
-                    onClick: openSecondScoreUplaodModal,
-                  },
-                  {
-                    icon: <IconEditDocument width={24} height={24} />,
-                    label: '2차 합격 여부 변경하기',
-                    value: 'update_second_round_result',
-                    onClick: () => {},
-                  },
-                  {
-                    icon: <IconEditAllDocument width={24} height={24} />,
-                    label: '2차 합격자 자동 선발',
-                    value: 'auto_select_second_round',
-                    onClick: () => {},
-                  },
-                  {
-                    icon: <IconUpload width={24} height={24} />,
-                    label: '명단 엑셀로 내보내기',
-                    value: 'export_excel',
-                    onClick: () => {},
-                  },
-                  {
-                    icon: <IconPrint width={24} height={24} />,
-                    label: '원서 출력하기',
-                    value: 'print_applications',
-                    onClick: () => {},
-                  },
-                  {
-                    icon: <IconAdmission width={24} height={24} />,
-                    label: '수험표 전체 발급하기',
-                    value: 'generate_all_exam_tickets',
-                    onClick: () => {},
-                  },
-                ]}
-              />
+              {isSecondRoundResultEditing ? (
+                <Row gap={16}>
+                  <Button
+                    styleType="SECONDARY"
+                    size="SMALL"
+                    onClick={setIsSecondRoundResultEditingFalse}
+                  >
+                    취소
+                  </Button>
+                  <Button size="SMALL" onClick={() => {}}>
+                    완료
+                  </Button>
+                </Row>
+              ) : (
+                <FunctionDropdown
+                  data={[
+                    {
+                      icon: <IconCheckDocument width={24} height={24} />,
+                      label: '검토해야하는 원서 모아보기',
+                      value: 'review_applications',
+                      onClick: handleFormListTypeReview,
+                    },
+                    {
+                      icon: <IconEditDocument width={24} height={24} />,
+                      label: '2차 전형 점수 입력하기',
+                      value: 'input_second_round_scores',
+                      onClick: openSecondScoreUplaodModal,
+                    },
+                    {
+                      icon: <IconEditDocument width={24} height={24} />,
+                      label: '2차 합격 여부 변경하기',
+                      value: 'update_second_round_result',
+                      onClick: setIsSecondRoundResultEditingTrue,
+                    },
+                    {
+                      icon: <IconEditAllDocument width={24} height={24} />,
+                      label: '2차 합격자 자동 선발',
+                      value: 'auto_select_second_round',
+                      onClick: () => {},
+                    },
+                    {
+                      icon: <IconUpload width={24} height={24} />,
+                      label: '명단 엑셀로 내보내기',
+                      value: 'export_excel',
+                      onClick: () => {},
+                    },
+                    {
+                      icon: <IconPrint width={24} height={24} />,
+                      label: '원서 출력하기',
+                      value: 'print_applications',
+                      onClick: () => {},
+                    },
+                    {
+                      icon: <IconAdmission width={24} height={24} />,
+                      label: '수험표 전체 발급하기',
+                      value: 'generate_all_exam_tickets',
+                      onClick: () => {},
+                    },
+                  ]}
+                />
+              )}
             </Row>
           </Row>
           <FormTable />

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -25,7 +25,6 @@ import { useEditSecondRoundResultActions, useFormPageState } from './form.hooks'
 import { color } from '@maru/design-system';
 import { useOverlay } from '@toss/use-overlay';
 import SecondScoreUploadModal from '@/components/form/SecondScoreUploadModal/SecondScoreUploadModal';
-import { useIsSecondRoundResultEditingStore } from '@/store/form/isSecondRoundResultEditing';
 
 const FormPage = () => {
   const {

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -21,7 +21,7 @@ import {
 import { Button, Column, Dropdown, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
-import { useFormPageState } from './form.hooks';
+import { useEditSecondRoundResultActions, useFormPageState } from './form.hooks';
 import { color } from '@maru/design-system';
 import { useOverlay } from '@toss/use-overlay';
 import SecondScoreUploadModal from '@/components/form/SecondScoreUploadModal/SecondScoreUploadModal';
@@ -36,13 +36,12 @@ const FormPage = () => {
     getCriteriaDropdownValue,
   } = useFormPageState();
 
-  const [isSecondRoundResultEditing, setIsSecondRoundResultEditing] =
-    useIsSecondRoundResultEditingStore();
-
-  const setIsSecondRoundResultEditingTrue = () => setIsSecondRoundResultEditing(true);
-  const setIsSecondRoundResultEditingFalse = () => {
-    setIsSecondRoundResultEditing(false);
-  };
+  const {
+    isSecondRoundResultEditing,
+    setIsSecondRoundResultEditingTrue,
+    setIsSecondRoundResultEditingFalse,
+    handleSecondRoundResultEditCompleteButtonClick,
+  } = useEditSecondRoundResultActions();
 
   const overlay = useOverlay();
 
@@ -156,7 +155,10 @@ const FormPage = () => {
                   >
                     취소
                   </Button>
-                  <Button size="SMALL" onClick={() => {}}>
+                  <Button
+                    size="SMALL"
+                    onClick={handleSecondRoundResultEditCompleteButtonClick}
+                  >
                     완료
                   </Button>
                 </Row>

--- a/apps/admin/src/components/form/FormTable/FormTable.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTable.tsx
@@ -13,11 +13,13 @@ const FormTable = () => {
         formList.map((item) => (
           <FormTableItem
             id={item.id}
+            birthday={item.birthday}
             examinationNumber={item.examinationNumber}
             name={item.name}
             graduationType={item.graduationType}
             school={item.school}
             status={item.status}
+            hasDocument={item.hasDocument}
             type={item.type}
             isChangedToRegular={item.isChangedToRegular}
             totalScore={item.totalScore}

--- a/apps/admin/src/components/form/FormTable/FormTableHeader/FormTableHeader.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableHeader/FormTableHeader.tsx
@@ -38,7 +38,7 @@ const FormTableHeader = () => {
       </Row>
       <Text
         fontType="p2"
-        width={isSecondRoundResultEditing ? 80 : convertToResponsive(40, 60)}
+        width={isSecondRoundResultEditing ? 100 : convertToResponsive(40, 60)}
       >
         2차 결과
       </Text>

--- a/apps/admin/src/components/form/FormTable/FormTableHeader/FormTableHeader.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableHeader/FormTableHeader.tsx
@@ -1,8 +1,11 @@
 import TableHeader from '@/components/common/TableHeader/TableHeader';
+import { useIsSecondRoundResultEditingValueStore } from '@/store/form/isSecondRoundResultEditing';
 import { convertToResponsive } from '@/utils';
 import { Row, Text } from '@maru/ui';
 
 const FormTableHeader = () => {
+  const isSecondRoundResultEditing = useIsSecondRoundResultEditingValueStore();
+
   return (
     <TableHeader>
       <Row gap={48}>
@@ -19,7 +22,7 @@ const FormTableHeader = () => {
           전형
         </Text>
       </Row>
-      <Row gap={48}>
+      <Row gap={48} justifyContent="flex-end">
         <Text fontType="p2" width={convertToResponsive(40, 60)}>
           제출상태
         </Text>
@@ -32,10 +35,13 @@ const FormTableHeader = () => {
         <Text fontType="p2" width={convertToResponsive(40, 60)}>
           최종 점수
         </Text>
-        <Text fontType="p2" width={convertToResponsive(40, 60)}>
-          2차 결과
-        </Text>
       </Row>
+      <Text
+        fontType="p2"
+        width={isSecondRoundResultEditing ? 80 : convertToResponsive(40, 60)}
+      >
+        2차 결과
+      </Text>
     </TableHeader>
   );
 };

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -1,4 +1,5 @@
 import { TableItem } from '@/components/common';
+import { Form } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
 import { Row, Text } from '@maru/ui';
@@ -21,12 +22,13 @@ const FormTableItem = ({
   id,
   examinationNumber,
   name,
-  school,
   graduationType,
+  school,
+  status,
   totalScore,
   firstRoundPassed,
   secondRoundPassed,
-}: FormTableItemProps) => {
+}: Form) => {
   const getStatusColor = (status: boolean | null) => {
     if (status === null) return color.gray600;
     return status ? color.maruDefault : color.red;
@@ -50,7 +52,7 @@ const FormTableItem = ({
       </Row>
       <Row gap={48}>
         <Text fontType="p2" width={convertToResponsive(40, 60)}>
-          최종 제출
+          {status === 'SUBMITTED' ? '초안 제출' : '최종 제출'}
         </Text>
         <Text fontType="p2" width={convertToResponsive(40, 60)}>
           승인

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -22,11 +22,11 @@ const FormTableItem = ({
     return status ? color.maruDefault : color.red;
   };
 
-  const getRoundResult = (roundPassed: boolean | null): string => {
-    if (roundPassed === null) {
-      return '미정';
+  const getRoundResult = (roundPassed: boolean | null, FormStatus?: string) => {
+    if (FormStatus === 'NO_SHOW') {
+      return '불참';
     }
-    return roundPassed ? '합격' : '불합격';
+    return roundPassed === null ? '미정' : roundPassed ? '합격' : '불합격';
   };
 
   return (
@@ -71,7 +71,7 @@ const FormTableItem = ({
           width={convertToResponsive(40, 60)}
           color={getStatusColor(secondRoundPassed)}
         >
-          {getRoundResult(secondRoundPassed)}
+          {getRoundResult(secondRoundPassed, status)}
         </Text>
       </Row>
     </TableItem>

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -73,7 +73,11 @@ const FormTableItem = ({
         >
           {getRoundResult(firstRoundPassed)}
         </Text>
-        <Text fontType="p2" width={convertToResponsive(40, 60)}>
+        <Text
+          fontType="p2"
+          width={convertToResponsive(40, 60)}
+          color={typeof totalScore !== 'number' ? color.gray600 : color.black}
+        >
           {typeof totalScore !== 'number' ? '미정' : Number(totalScore.toFixed(3))}
         </Text>
         <Text

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -84,7 +84,7 @@ const FormTableItem = ({
           <Dropdown
             name="pass"
             size="SMALL"
-            width={80}
+            width={100}
             value={secondRoundResult[id] || getRoundResult(secondRoundPassed, status)}
             data={['합격', '불합격']}
             onChange={handleSecondPassResultDropdownChange}

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -1,4 +1,5 @@
 import { TableItem } from '@/components/common';
+import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
 import { Form } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
@@ -25,7 +26,7 @@ const FormTableItem = ({
   graduationType,
   school,
   status,
-
+  type,
   totalScore,
   firstRoundPassed,
   secondRoundPassed,
@@ -48,7 +49,7 @@ const FormTableItem = ({
           {graduationType === 'QUALIFICATION_EXAMINATION' ? '검정고시' : school}
         </Text>
         <Text fontType="p2" width={convertToResponsive(180, 240)}>
-          {graduationType}
+          {FORM_TYPE_CATEGORY[type]}
         </Text>
       </Row>
       <Row gap={48}>

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -2,7 +2,7 @@ import { TableItem } from '@/components/common';
 import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
 import { useIsSecondRoundResultEditingValueStore } from '@/store/form/isSecondRoundResultEditing';
 import { useSecondRoundResultStore } from '@/store/form/secondRoundResult';
-import { Form, PassStatusType } from '@/types/form/client';
+import type { Form, PassStatusType } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
 import { Dropdown, Row, Text } from '@maru/ui';

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -1,6 +1,6 @@
 import { TableItem } from '@/components/common';
 import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
-import { Form } from '@/types/form/client';
+import { Form, FormStatus } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
 import { Row, Text } from '@maru/ui';
@@ -36,6 +36,13 @@ const FormTableItem = ({
     return status ? color.maruDefault : color.red;
   };
 
+  const getRoundResult = (roundPassed: boolean | null): string => {
+    if (roundPassed === null) {
+      return '미정';
+    }
+    return roundPassed ? '합격' : '불합격';
+  };
+
   return (
     <TableItem key={id}>
       <Row gap={48}>
@@ -64,7 +71,7 @@ const FormTableItem = ({
           width={convertToResponsive(40, 60)}
           color={getStatusColor(firstRoundPassed)}
         >
-          합격
+          {getRoundResult(firstRoundPassed)}
         </Text>
         <Text fontType="p2" width={convertToResponsive(40, 60)}>
           {typeof totalScore !== 'number' ? '미정' : Number(totalScore.toFixed(3))}
@@ -74,7 +81,7 @@ const FormTableItem = ({
           width={convertToResponsive(40, 60)}
           color={getStatusColor(secondRoundPassed)}
         >
-          합격
+          {getRoundResult(secondRoundPassed)}
         </Text>
       </Row>
     </TableItem>

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -1,9 +1,11 @@
 import { TableItem } from '@/components/common';
 import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
-import { Form } from '@/types/form/client';
+import { useIsSecondRoundResultEditingValueStore } from '@/store/form/isSecondRoundResultEditing';
+import { useSecondRoundResultStore } from '@/store/form/secondRoundResult';
+import { Form, PassStatusType } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
-import { Row, Text } from '@maru/ui';
+import { Dropdown, Row, Text } from '@maru/ui';
 
 const FormTableItem = ({
   id,
@@ -17,6 +19,16 @@ const FormTableItem = ({
   firstRoundPassed,
   secondRoundPassed,
 }: Form) => {
+  const isSecondRoundResultEditing = useIsSecondRoundResultEditingValueStore();
+  const [secondRoundResult, setSecondRoundResult] = useSecondRoundResultStore();
+
+  const handleSecondPassResultDropdownChange = (value: string) => {
+    setSecondRoundResult((prev) => ({
+      ...prev,
+      [id]: value as PassStatusType,
+    }));
+  };
+
   const getStatusColor = (status: boolean | null) => {
     if (status === null) return color.gray600;
     return status ? color.maruDefault : color.red;
@@ -45,7 +57,7 @@ const FormTableItem = ({
           {FORM_TYPE_CATEGORY[type]}
         </Text>
       </Row>
-      <Row gap={48}>
+      <Row gap={48} justify-content="flex-end">
         <Text fontType="p2" width={convertToResponsive(40, 60)}>
           {status === 'SUBMITTED' ? '초안 제출' : '최종 제출'}
         </Text>
@@ -66,13 +78,26 @@ const FormTableItem = ({
         >
           {typeof totalScore !== 'number' ? '미정' : Number(totalScore.toFixed(3))}
         </Text>
-        <Text
-          fontType="p2"
-          width={convertToResponsive(40, 60)}
-          color={getStatusColor(secondRoundPassed)}
-        >
-          {getRoundResult(secondRoundPassed, status)}
-        </Text>
+      </Row>
+      <Row>
+        {isSecondRoundResultEditing ? (
+          <Dropdown
+            name="pass"
+            size="SMALL"
+            width={80}
+            value={secondRoundResult[id] || getRoundResult(secondRoundPassed, status)}
+            data={['합격', '불합격']}
+            onChange={handleSecondPassResultDropdownChange}
+          />
+        ) : (
+          <Text
+            fontType="p2"
+            width={convertToResponsive(40, 60)}
+            color={getStatusColor(secondRoundPassed)}
+          >
+            {getRoundResult(secondRoundPassed, status)}
+          </Text>
+        )}
       </Row>
     </TableItem>
   );

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -1,23 +1,9 @@
 import { TableItem } from '@/components/common';
 import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
-import { Form, FormStatus } from '@/types/form/client';
+import { Form } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
 import { Row, Text } from '@maru/ui';
-
-interface FormTableItemProps {
-  id: number;
-  examinationNumber: number | null;
-  name: string;
-  graduationType: string;
-  school: string;
-  status: string;
-  type: string;
-  isChangedToRegular: boolean;
-  totalScore: number | null;
-  firstRoundPassed: boolean | null;
-  secondRoundPassed: boolean | null;
-}
 
 const FormTableItem = ({
   id,

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -25,6 +25,7 @@ const FormTableItem = ({
   graduationType,
   school,
   status,
+
   totalScore,
   firstRoundPassed,
   secondRoundPassed,
@@ -44,7 +45,7 @@ const FormTableItem = ({
           {name}
         </Text>
         <Text fontType="p2" width={convertToResponsive(120, 160)}>
-          {school}
+          {graduationType === 'QUALIFICATION_EXAMINATION' ? '검정고시' : school}
         </Text>
         <Text fontType="p2" width={convertToResponsive(180, 240)}>
           {graduationType}

--- a/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
+++ b/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
@@ -19,7 +19,7 @@ const SecondScoreUploader = ({ isOpen }: SecondScoreUploaderProps) => {
     if (isOpen && uploadedFile) {
       setUploadedFile(null);
     }
-  }, [isOpen, setUploadedFile]);
+  }, [isOpen, uploadedFile, setUploadedFile]);
 
   const handleUploadCancelButtonClick = () => {
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -52,7 +52,7 @@ export const patchSecondRoundResult = async (
   secondRoundResultData: PatchSecondRoundResultReq
 ) => {
   const { data } = await maru.patch(
-    '/form/second-round/result',
+    '/forms/second-round/result',
     secondRoundResultData,
     authorization()
   );

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -1,7 +1,7 @@
 import { maru } from '@/apis/instance/instance';
 import { authorization } from '@/apis/token';
 import type { FormListSortingType, FormListType } from '@/types/form/client';
-import type { GetFormListRes } from '@/types/form/remote';
+import type { GetFormListRes, PatchSecondRoundResultReq } from '@/types/form/remote';
 
 export const getFormList = async (
   formListType: FormListType,
@@ -43,6 +43,18 @@ export const patchSecondScoreFormat = async (formData: FormData) => {
     '/forms/second-round/score',
     formData,
     authorization.FormData()
+  );
+
+  return data;
+};
+
+export const patchSecondRoundResult = async (
+  secondRoundResultData: PatchSecondRoundResultReq
+) => {
+  const { data } = await maru.patch(
+    '/form/second-round/result',
+    secondRoundResultData,
+    authorization()
   );
 
   return data;

--- a/apps/admin/src/services/form/mutations.ts
+++ b/apps/admin/src/services/form/mutations.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { patchSecondRoundResult, patchSecondScoreFormat } from './api';
 import { toast } from 'react-toastify';
 import { KEY } from '@/constants/common/constant';
-import { PatchSecondRoundResultReq } from '@/types/form/remote';
+import type { PatchSecondRoundResultReq } from '@/types/form/remote';
 import { useSetIsSecondRoundResultEditingStore } from '@/store/form/isSecondRoundResultEditing';
 import { useSetSecondRoundResultStore } from '@/store/form/secondRoundResult';
 

--- a/apps/admin/src/services/form/mutations.ts
+++ b/apps/admin/src/services/form/mutations.ts
@@ -1,8 +1,11 @@
 import { useApiError } from '@/hooks';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { patchSecondScoreFormat } from './api';
+import { patchSecondRoundResult, patchSecondScoreFormat } from './api';
 import { toast } from 'react-toastify';
 import { KEY } from '@/constants/common/constant';
+import { PatchSecondRoundResultReq } from '@/types/form/remote';
+import { useSetIsSecondRoundResultEditingStore } from '@/store/form/isSecondRoundResultEditing';
+import { useSetSecondRoundResultStore } from '@/store/form/secondRoundResult';
 
 export const useUploadSecondScoreFormatMutation = (handleCloseModal: () => void) => {
   const { handleError } = useApiError();
@@ -19,4 +22,29 @@ export const useUploadSecondScoreFormatMutation = (handleCloseModal: () => void)
   });
 
   return { uploadSecondScoreFormat, ...restMutation };
+};
+
+export const useEditSecondRoundResultMutation = (
+  secondRoundResultData: PatchSecondRoundResultReq
+) => {
+  const { handleError } = useApiError();
+  const queryClient = useQueryClient();
+
+  const setIsSecondRoundResultEditing = useSetIsSecondRoundResultEditingStore();
+  const setSecondRoundResult = useSetSecondRoundResultStore();
+
+  const { mutate: editSecondRoundResult, ...restMutation } = useMutation({
+    mutationFn: () => patchSecondRoundResult(secondRoundResultData),
+    onSuccess: () => {
+      toast('2차 합격 여부가 반영되었습니다.', {
+        type: 'success',
+      });
+      queryClient.invalidateQueries({ queryKey: [KEY.FORM_LIST] });
+      setIsSecondRoundResultEditing(false);
+      setSecondRoundResult({});
+    },
+    onError: handleError,
+  });
+
+  return { editSecondRoundResult, ...restMutation };
 };

--- a/apps/admin/src/store/form/isSecondRoundResultEditing.ts
+++ b/apps/admin/src/store/form/isSecondRoundResultEditing.ts
@@ -1,0 +1,13 @@
+import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
+const isSecondRoundResultEditingAtomState = atom<boolean>({
+  key: 'is-second-round-result-editing',
+  default: false,
+});
+
+export const useIsSecondRoundResultEditingStore = () =>
+  useRecoilState(isSecondRoundResultEditingAtomState);
+export const useIsSecondRoundResultEditingValueStore = () =>
+  useRecoilValue(isSecondRoundResultEditingAtomState);
+export const useSetIsSecondRoundResultEditingStore = () =>
+  useSetRecoilState(isSecondRoundResultEditingAtomState);

--- a/apps/admin/src/store/form/secondRoundResult.ts
+++ b/apps/admin/src/store/form/secondRoundResult.ts
@@ -1,0 +1,13 @@
+import type { PassStatusType } from '@/types/form/client';
+import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
+const secondRoundResultAtomState = atom<Record<number, PassStatusType>>({
+  key: 'second-round-result',
+  default: {},
+});
+
+export const useSecondRoundResultStore = () => useRecoilState(secondRoundResultAtomState);
+export const useSecondRoundResultValueStore = () =>
+  useRecoilValue(secondRoundResultAtomState);
+export const useSetSecondRoundResultStore = () =>
+  useSetRecoilState(secondRoundResultAtomState);

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -28,6 +28,8 @@ export type FormType =
 
 export type GraduationType = 'EXPECTED' | 'GRADUATED' | 'QUALIFICATION_EXAMINATION';
 
+export type PassStatusType = '합격' | '불합격' | '미정';
+
 export interface Form {
   id: number;
   examinationNumber: number | null;

--- a/apps/admin/src/types/form/remote.ts
+++ b/apps/admin/src/types/form/remote.ts
@@ -3,3 +3,7 @@ import type { Form } from './client';
 export interface GetFormListRes {
   dataList: Form[];
 }
+
+export interface PatchSecondRoundResultReq {
+  formList: { formId: number; pass: boolean | null }[];
+}


### PR DESCRIPTION
## 📄 Summary

> 어드민 원서 관리 페이지의 FunctionDropdown 기능 중 - 2차 합격 여부 변경하기 기능을 추가 했습니다.

<br>

## 🔨 Tasks

- 원서 상태에 따른 각 항목 표시 적용
- 2차 합격 여부 변경 API 연동
- 관련 전역 상태 정의(isSecondRoundResultEditingAtomState, secondRoundResultAtomState)
- 2차 합격 여부 변경 시 invalidateQueries 통해 FORM_LIST 재조회

<br>

## 🙋🏻 More
제출 서류의 상태를 변경하는 기능은 해당 기능에서 처리하지 않도록 결정하여 원서 상세 조회에서 추가하겠습니다.
![image](https://github.com/user-attachments/assets/2e0ffea3-4ea4-47e0-9ab8-b98814667239)
![image](https://github.com/user-attachments/assets/92745d00-e202-489f-8608-86994e172eda)
