### PR TITLE
feat(admin): 2차 합격자 자동 선발 기능 추가

### DIFF
--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -25,6 +25,7 @@ import { useEditSecondRoundResultActions, useFormPageState } from './form.hooks'
 import { color } from '@maru/design-system';
 import { useOverlay } from '@toss/use-overlay';
 import SecondScoreUploadModal from '@/components/form/SecondScoreUploadModal/SecondScoreUploadModal';
+import { useAutoSecondRoundResultMutation } from '@/services/form/mutations';
 
 const FormPage = () => {
   const {
@@ -48,6 +49,12 @@ const FormPage = () => {
     overlay.open(({ isOpen, close }) => (
       <SecondScoreUploadModal isOpen={isOpen} onClose={close} />
     ));
+  };
+
+  const { autoSecondRoundResult } = useAutoSecondRoundResultMutation();
+
+  const handleAutoSecondRoundResult = () => {
+    autoSecondRoundResult();
   };
 
   return (
@@ -186,7 +193,7 @@ const FormPage = () => {
                       icon: <IconEditAllDocument width={24} height={24} />,
                       label: '2차 합격자 자동 선발',
                       value: 'auto_select_second_round',
-                      onClick: () => {},
+                      onClick: handleAutoSecondRoundResult,
                     },
                     {
                       icon: <IconUpload width={24} height={24} />,

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -59,3 +59,9 @@ export const patchSecondRoundResult = async (
 
   return data;
 };
+
+export const patchSecondRoundResultAuto = async () => {
+  const { data } = await maru.patch('/forms/second-round/select', authorization());
+
+  return data;
+};

--- a/apps/admin/src/services/form/mutations.ts
+++ b/apps/admin/src/services/form/mutations.ts
@@ -1,6 +1,10 @@
 import { useApiError } from '@/hooks';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { patchSecondRoundResult, patchSecondScoreFormat } from './api';
+import {
+  patchSecondRoundResult,
+  patchSecondRoundResultAuto,
+  patchSecondScoreFormat,
+} from './api';
 import { toast } from 'react-toastify';
 import { KEY } from '@/constants/common/constant';
 import type { PatchSecondRoundResultReq } from '@/types/form/remote';
@@ -47,4 +51,22 @@ export const useEditSecondRoundResultMutation = (
   });
 
   return { editSecondRoundResult, ...restMutation };
+};
+
+export const useAutoSecondRoundResultMutation = () => {
+  const { handleError } = useApiError();
+  const queryClient = useQueryClient();
+
+  const { mutate: autoSecondRoundResult, ...restMutation } = useMutation({
+    mutationFn: patchSecondRoundResultAuto,
+    onSuccess: () => {
+      toast('2차 합격 여부가 모두 반영되었습니다.', {
+        type: 'success',
+      });
+      queryClient.invalidateQueries({ queryKey: [KEY.FORM_LIST] });
+    },
+    onError: handleError,
+  });
+
+  return { autoSecondRoundResult, ...restMutation };
 };


### PR DESCRIPTION
## 📄 Summary

> 어드민 원서 관리 페이지의 FunctionDropdown 기능 중 - 2차 합격자 자동 선발 기능을 추가 했습니다.

<br>

## 🔨 Tasks

- 자동선발 API 연동
- 2차 합격자 자동 선발 기능 추가
- 자동 선발 시 FORM_LIST 재조회

<br>

## 🙋🏻 More
