### PR TITLE
feat(admin): 수험표 전체 발급하기 기능 추가

### DIFF
--- a/apps/admin/src/app/form/form.hooks.ts
+++ b/apps/admin/src/app/form/form.hooks.ts
@@ -2,6 +2,7 @@ import {
   useEditSecondRoundResultMutation,
   usePrintFormUrlMutation,
 } from '@/services/form/mutations';
+import { useExportAllAddmissionTicket } from '@/services/form/queries';
 import {
   useFormToPrintValueStore,
   useSetFormToPrintStore,
@@ -110,4 +111,23 @@ export const usePrintFormURLActions = () => {
     setIsFormToPrintSelectingFalse,
     handlePrintFormUrlButtonClick,
   };
+};
+
+export const useExportAllAddmissionTicketAction = () => {
+  const { data: exportTicketData } = useExportAllAddmissionTicket();
+
+  const handleExportAllAdmissionTicketButtonClick = () => {
+    if (!exportTicketData) return;
+    const ticketURL = window.URL.createObjectURL(new Blob([exportTicketData]));
+
+    const link = document.createElement('a');
+    link.href = ticketURL;
+    link.download = '전체 접수증.pdf';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(ticketURL);
+  };
+
+  return { handleExportAllAdmissionTicketButtonClick };
 };

--- a/apps/admin/src/app/form/page.tsx
+++ b/apps/admin/src/app/form/page.tsx
@@ -23,6 +23,7 @@ import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
 import {
   useEditSecondRoundResultActions,
+  useExportAllAddmissionTicketAction,
   useFormPageState,
   usePrintFormURLActions,
 } from './form.hooks';
@@ -54,6 +55,9 @@ const FormPage = () => {
     setIsFormToPrintSelectingFalse,
     handlePrintFormUrlButtonClick,
   } = usePrintFormURLActions();
+
+  const { handleExportAllAdmissionTicketButtonClick } =
+    useExportAllAddmissionTicketAction();
 
   const overlay = useOverlay();
 
@@ -241,8 +245,8 @@ const FormPage = () => {
                     {
                       icon: <IconAdmission width={24} height={24} />,
                       label: '수험표 전체 발급하기',
-                      value: 'generate_all_exam_tickets',
-                      onClick: () => {},
+                      value: 'export_all_exam_tickets',
+                      onClick: handleExportAllAdmissionTicketButtonClick,
                     },
                   ]}
                 />

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -7,6 +7,7 @@ export const KEY = {
   FORM_LIST: 'useFormList',
   SECOND_SCORE_FORMAT: 'useSecondScoreFormat',
   FORM_EXPORT_EXCEL: 'useFormExportExcel',
+  FORM_EXPORT_ALL_ADMISSION_TICKET: 'useFormExportAllAdmissionTicket',
   FAIR_LIST: 'useFairList',
   FAIR_DETAIL: 'useFairDetail',
   FAIR_EXPORT_EXCEL: 'useFairExportExcel',

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -69,7 +69,7 @@ export const getFormUrl = async (formIdList: number[]) => {
 };
 
 export const getAllAdmissionTicket = async () => {
-  const { data } = await maru.get('/forms/admission-ticket/all', {
+  const { data } = await maru.get('/forms/admission-tickets', {
     ...authorization(),
     responseType: 'blob',
   });

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -68,6 +68,15 @@ export const getFormUrl = async (formIdList: number[]) => {
   return data;
 };
 
+export const getAllAdmissionTicket = async () => {
+  const { data } = await maru.get('/forms/admission-ticket/all', {
+    ...authorization(),
+    responseType: 'blob',
+  });
+
+  return data;
+};
+
 export const patchSecondScoreFormat = async (formData: FormData) => {
   const { data } = await maru.patch(
     '/forms/second-round/score',

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -1,5 +1,10 @@
 import { KEY } from '@/constants/common/constant';
-import { getExportExcel, getFormList, getSecondScoreFormat } from './api';
+import {
+  getAllAdmissionTicket,
+  getExportExcel,
+  getFormList,
+  getSecondScoreFormat,
+} from './api';
 import { useQuery } from '@tanstack/react-query';
 import {
   useFormListSortingTypeValueStore,
@@ -32,6 +37,15 @@ export const useExportExcelQuery = (exportExcelType: ExportExcelType) => {
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.FORM_EXPORT_EXCEL, exportExcelType],
     queryFn: () => getExportExcel(exportExcelType),
+  });
+
+  return { data, ...restQuery };
+};
+
+export const useExportAllAddmissionTicket = () => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.FORM_EXPORT_ALL_ADMISSION_TICKET],
+    queryFn: () => getAllAdmissionTicket(),
   });
 
   return { data, ...restQuery };


### PR DESCRIPTION
## 📄 Summary

> 어드민 원서 관리 페이지의 FunctionDropdown 기능 중 - 수험표 전체 발급하기 기능을 추가했습니다.

<br>

## 🔨 Tasks

- 수험표 전체 발급 API 연동
- 핸들링 시 자동 다운로드

<br>

## 🙋🏻 More
