### PR TITLE
feat(admin): 원서 상세조회 프로필 추가

### DIFF
--- a/apps/admin/src/app/form/[id]/page.tsx
+++ b/apps/admin/src/app/form/[id]/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import FormDetail from '@/components/form/FormDetail/FormDetail';
 import { ROUTES } from '@/constants/common/constant';
 import AppLayout from '@/layouts/AppLayout';

--- a/apps/admin/src/app/form/[id]/page.tsx
+++ b/apps/admin/src/app/form/[id]/page.tsx
@@ -1,3 +1,4 @@
+import FormDetail from '@/components/form/FormDetail/FormDetail';
 import { ROUTES } from '@/constants/common/constant';
 import AppLayout from '@/layouts/AppLayout';
 import { color, font } from '@maru/design-system';
@@ -18,10 +19,13 @@ const FormDetailPage = ({ params: { id } }: FormDetailPageProps) => {
           <IconArrowLeft width={18} height={18} />
           돌아가기
         </DirectLink>
+        <FormDetail id={id} />
       </StyledFormDetail>
     </AppLayout>
   );
 };
+
+export default FormDetailPage;
 
 const StyledFormDetail = styled.div`
   position: relative;

--- a/apps/admin/src/app/form/[id]/page.tsx
+++ b/apps/admin/src/app/form/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { ROUTES } from '@/constants/common/constant';
+import AppLayout from '@/layouts/AppLayout';
+import { color, font } from '@maru/design-system';
+import { IconArrowLeft } from '@maru/icon';
+import { flex } from '@maru/utils';
+import Link from 'next/link';
+import { styled } from 'styled-components';
+
+interface FormDetailPageProps {
+  params: { id: number };
+}
+
+const FormDetailPage = ({ params: { id } }: FormDetailPageProps) => {
+  return (
+    <AppLayout>
+      <StyledFormDetail>
+        <DirectLink href={ROUTES.FORM}>
+          <IconArrowLeft width={18} height={18} />
+          돌아가기
+        </DirectLink>
+      </StyledFormDetail>
+    </AppLayout>
+  );
+};
+
+const StyledFormDetail = styled.div`
+  position: relative;
+  ${flex({ flexDirection: 'column' })}
+  gap: 24px;
+  width: 100%;
+  min-height: 100vh;
+  padding: 48px 60px 82px;
+`;
+
+const DirectLink = styled(Link)`
+  ${flex({ alignItems: 'center' })}
+  gap: 2px;
+  ${font.p3}
+  color: ${color.gray600};
+`;

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -1,9 +1,10 @@
 import { FORM_DETAIL_STEP_LIST } from '@/constants/form/constant';
 import { color } from '@maru/design-system';
-import { Column, Row, UnderlineButton } from '@maru/ui';
+import { Column, UnderlineButton } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { useState } from 'react';
 import { styled } from 'styled-components';
+import { useFormDetailDataDecomposition } from './formDetail.hooks';
 
 interface FormDetailProps {
   id: number;
@@ -11,8 +12,11 @@ interface FormDetailProps {
 
 const FormDetail = ({ id }: FormDetailProps) => {
   const [currentFormDetailStep, setCurrentFormDetailStep] = useState('지원자 정보');
+
+  const { profileData } = useFormDetailDataDecomposition(id);
+
   return (
-    <StyledFormDetailContent>
+    <StyledFormDetail>
       <Column gap={36}>
         {`프로필`}
         {`원서상태`}
@@ -30,13 +34,13 @@ const FormDetail = ({ id }: FormDetailProps) => {
           ))}
         </NavigationBar>
       </Column>
-    </StyledFormDetailContent>
+    </StyledFormDetail>
   );
 };
 
 export default FormDetail;
 
-const StyledFormDetailContent = styled.div`
+const StyledFormDetail = styled.div`
   display: flex;
   gap: 48px;
   width: 100%;

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -1,6 +1,6 @@
 import { FORM_DETAIL_STEP_LIST } from '@/constants/form/constant';
 import { color } from '@maru/design-system';
-import { Column, Loader, UnderlineButton } from '@maru/ui';
+import { Column, UnderlineButton } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { useState } from 'react';
 import { styled } from 'styled-components';
@@ -20,7 +20,7 @@ const FormDetail = ({ id }: FormDetailProps) => {
     <StyledFormDetail>
       <Column gap={36}>
         <Profile profileData={profileData} />
-        {`원서상태 백엔드 수정되면 개발`}
+        {/**원서상태 백엔드 수정되면 개발**/}
       </Column>
       <Column gap={48}>
         <NavigationBar>

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -1,10 +1,11 @@
 import { FORM_DETAIL_STEP_LIST } from '@/constants/form/constant';
 import { color } from '@maru/design-system';
-import { Column, UnderlineButton } from '@maru/ui';
+import { Column, Loader, UnderlineButton } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 import { useFormDetailDataDecomposition } from './formDetail.hooks';
+import Profile from './Profile/Profile';
 
 interface FormDetailProps {
   id: number;
@@ -18,8 +19,8 @@ const FormDetail = ({ id }: FormDetailProps) => {
   return (
     <StyledFormDetail>
       <Column gap={36}>
-        {`프로필`}
-        {`원서상태`}
+        <Profile profileData={profileData} />
+        {`원서상태 백엔드 수정되면 개발`}
       </Column>
       <Column gap={48}>
         <NavigationBar>

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -1,0 +1,50 @@
+import { FORM_DETAIL_STEP_LIST } from '@/constants/form/constant';
+import { color } from '@maru/design-system';
+import { Column, Row, UnderlineButton } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+interface FormDetailProps {
+  id: number;
+}
+
+const FormDetail = ({ id }: FormDetailProps) => {
+  const [currentFormDetailStep, setCurrentFormDetailStep] = useState('지원자 정보');
+  return (
+    <StyledFormDetailContent>
+      <Column gap={36}>
+        {`프로필`}
+        {`원서상태`}
+      </Column>
+      <Column gap={48}>
+        <NavigationBar>
+          {FORM_DETAIL_STEP_LIST.map((formDetailStep, index) => (
+            <UnderlineButton
+              key={`form-detail-step ${index}`}
+              active={formDetailStep === currentFormDetailStep}
+              onClick={() => setCurrentFormDetailStep(formDetailStep)}
+            >
+              {formDetailStep}
+            </UnderlineButton>
+          ))}
+        </NavigationBar>
+      </Column>
+    </StyledFormDetailContent>
+  );
+};
+
+export default FormDetail;
+
+const StyledFormDetailContent = styled.div`
+  display: flex;
+  gap: 48px;
+  width: 100%;
+`;
+
+const NavigationBar = styled.div`
+  ${flex({ alignItems: 'center' })}
+  width: 100%;
+  height: 60px;
+  background-color: ${color.white};
+`;

--- a/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
+++ b/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
@@ -1,12 +1,12 @@
 import { color } from '@maru/design-system';
 import { IconBadge, IconCall, IconPerson, IconSchool } from '@maru/icon';
-import { Column, Row, Text } from '@maru/ui';
+import { Column, Loader, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import Image from 'next/image';
 import { styled } from 'styled-components';
 
 interface ProfileProps {
-  profileData: {
+  profileData?: {
     profileImageUrl: string;
     name: string;
     phoneNumber: string;
@@ -17,6 +17,8 @@ interface ProfileProps {
 }
 
 const Profile = ({ profileData }: ProfileProps) => {
+  if (!profileData) return <Loader />;
+
   const profileDetails = [
     {
       icon: <IconBadge width={24} height={24} />,

--- a/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
+++ b/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
@@ -1,5 +1,6 @@
 import { color } from '@maru/design-system';
-import { Column, Text } from '@maru/ui';
+import { IconBadge, IconCall, IconPerson, IconSchool } from '@maru/icon';
+import { Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import Image from 'next/image';
 import { styled } from 'styled-components';
@@ -16,6 +17,25 @@ interface ProfileProps {
 }
 
 const Profile = ({ profileData }: ProfileProps) => {
+  const profileDetails = [
+    {
+      icon: <IconBadge width={24} height={24} />,
+      value: profileData.examinationNumber,
+    },
+    {
+      icon: <IconPerson width={24} height={24} />,
+      value: profileData.type,
+    },
+    {
+      icon: <IconSchool width={24} height={24} />,
+      value: profileData.schoolName,
+    },
+    {
+      icon: <IconCall width={24} height={24} />,
+      value: profileData.phoneNumber,
+    },
+  ];
+
   return (
     <StyledProfile>
       <ProfileImageBox>
@@ -31,7 +51,16 @@ const Profile = ({ profileData }: ProfileProps) => {
         <Text fontType="H2" color={color.gray900}>
           {profileData.name}
         </Text>
-        <Column gap={8}>{`번호, 전형, 학교, 전번`}</Column>
+        <Column gap={8}>
+          {profileDetails.map((detail, index) => (
+            <Row key={index} gap={10}>
+              {detail.icon}
+              <Text fontType="p2" color={color.gray900}>
+                {detail.value}
+              </Text>
+            </Row>
+          ))}
+        </Column>
       </Column>
     </StyledProfile>
   );

--- a/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
+++ b/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
@@ -4,15 +4,32 @@ import { flex } from '@maru/utils';
 import Image from 'next/image';
 import { styled } from 'styled-components';
 
-const Profile = () => {
+interface ProfileProps {
+  profileData: {
+    profileImageUrl: string;
+    name: string;
+    phoneNumber: string;
+    examinationNumber: number;
+    type: string;
+    schoolName: string;
+  };
+}
+
+const Profile = ({ profileData }: ProfileProps) => {
   return (
     <StyledProfile>
       <ProfileImageBox>
-        <ProfileImage />
+        <ProfileImage
+          src={profileData.profileImageUrl}
+          alt="profile-image"
+          width={280}
+          height={280}
+          style={{ objectFit: 'cover', objectPosition: 'top' }}
+        />
       </ProfileImageBox>
       <Column gap={16}>
         <Text fontType="H2" color={color.gray900}>
-          {'이름'}
+          {profileData.name}
         </Text>
         <Column gap={8}>{`번호, 전형, 학교, 전번`}</Column>
       </Column>

--- a/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
+++ b/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
@@ -1,0 +1,36 @@
+import { color } from '@maru/design-system';
+import { Column, Text } from '@maru/ui';
+import { flex } from '@maru/utils';
+import Image from 'next/image';
+import { styled } from 'styled-components';
+
+const Profile = () => {
+  return (
+    <StyledProfile>
+      <ProfileImageBox>
+        <ProfileImage />
+      </ProfileImageBox>
+      <Column gap={16}>
+        <Text fontType="H2" color={color.gray900}>
+          {'이름'}
+        </Text>
+        <Column gap={8}>{`번호, 전형, 학교, 전번`}</Column>
+      </Column>
+    </StyledProfile>
+  );
+};
+export default Profile;
+
+const StyledProfile = styled.div`
+  ${flex({ flexDirection: 'column' })}
+  gap: 8px;
+`;
+
+const ProfileImageBox = styled.div`
+  width: 280px;
+  height: 280px;
+`;
+
+const ProfileImage = styled(Image)`
+  border-radius: 999px;
+`;

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -1,0 +1,23 @@
+import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
+import { useFormDetailQuery } from '@/services/form/queries';
+
+export const useFormDetailDataDecomposition = (id: number) => {
+  const { data: formDetailData } = useFormDetailQuery(id);
+
+  const profileData = formDetailData && {
+    profileImageUrl: formDetailData.applicant.identificationPictureUri,
+    name: formDetailData.applicant.name,
+    phoneNumber: formDetailData.applicant.phoneNumber,
+    examinationNumber: formDetailData.examinationNumber,
+    type:
+      formDetailData.changedToRegular && formDetailData.type === 'REGULAR'
+        ? '특별전형 -> 일반전형'
+        : FORM_TYPE_CATEGORY[formDetailData.type],
+    schoolName:
+      formDetailData.education.graduationType !== 'QUALIFICATION_EXAMINATION'
+        ? formDetailData.education.schoolName
+        : '검정고시',
+  };
+
+  return { profileData };
+};

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -11,6 +11,7 @@ import { color } from '@maru/design-system';
 import { CheckBox, Dropdown, Row, Text } from '@maru/ui';
 import { useRouter } from 'next/navigation';
 import type { ChangeEventHandler } from 'react';
+import { styled } from 'styled-components';
 
 const FormTableItem = ({
   id,
@@ -49,7 +50,6 @@ const FormTableItem = ({
   };
 
   const isFormToPrintSelecting = useIsFormToPrintSelectingValueStore();
-
   const [formToPrint, setFormToPrint] = useFormToPrintStore();
 
   const handleFormToPrintSelectChange: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -57,69 +57,89 @@ const FormTableItem = ({
     setFormToPrint((prev) => ({ ...prev, [id]: checked }));
   };
 
+  const isDisabled = isSecondRoundResultEditing || isFormToPrintSelecting;
+  const handleMoveFormDetailPage = () => {
+    if (isDisabled) return;
+    router.push(`${ROUTES.FORM}/${id}`);
+  };
+
   return (
-    <TableItem key={id} onClick={router.push(`${ROUTES.FORM}/${id}`)}>
-      <Row gap={48}>
-        {isFormToPrintSelecting ? (
-          <CheckBox checked={formToPrint[id]} onChange={handleFormToPrintSelectChange} />
-        ) : null}
-        <Text fontType="p2" width={convertToResponsive(40, 60)}>
-          {examinationNumber}
-        </Text>
-        <Text fontType="p2" width={convertToResponsive(40, 60)}>
-          {name}
-        </Text>
-        <Text fontType="p2" width={convertToResponsive(120, 160)}>
-          {graduationType === 'QUALIFICATION_EXAMINATION' ? '검정고시' : school}
-        </Text>
-        <Text fontType="p2" width={convertToResponsive(180, 240)}>
-          {FORM_TYPE_CATEGORY[type]}
-        </Text>
-      </Row>
-      <Row gap={48} justify-content="flex-end">
-        <Text fontType="p2" width={convertToResponsive(40, 60)}>
-          {status === 'SUBMITTED' ? '초안 제출' : '최종 제출'}
-        </Text>
-        <Text fontType="p2" width={convertToResponsive(40, 60)}>
-          승인
-        </Text>
-        <Text
-          fontType="p2"
-          width={convertToResponsive(40, 60)}
-          color={getStatusColor(firstRoundPassed)}
-        >
-          {getRoundResult(firstRoundPassed)}
-        </Text>
-        <Text
-          fontType="p2"
-          width={convertToResponsive(40, 60)}
-          color={typeof totalScore !== 'number' ? color.gray600 : color.black}
-        >
-          {typeof totalScore !== 'number' ? '미정' : Number(totalScore.toFixed(3))}
-        </Text>
-      </Row>
-      <Row>
-        {isSecondRoundResultEditing ? (
-          <Dropdown
-            name="pass"
-            size="SMALL"
-            width={100}
-            value={secondRoundResult[id] || getRoundResult(secondRoundPassed, status)}
-            data={['합격', '불합격']}
-            onChange={handleSecondPassResultDropdownChange}
-          />
-        ) : (
+    <DirectButton
+      style={{
+        cursor: isDisabled ? 'default' : 'pointer',
+      }}
+      onClick={handleMoveFormDetailPage}
+    >
+      <TableItem key={id}>
+        <Row gap={48}>
+          {isFormToPrintSelecting ? (
+            <CheckBox
+              checked={formToPrint[id]}
+              onChange={handleFormToPrintSelectChange}
+            />
+          ) : null}
+          <Text fontType="p2" width={convertToResponsive(40, 60)}>
+            {examinationNumber}
+          </Text>
+          <Text fontType="p2" width={convertToResponsive(40, 60)}>
+            {name}
+          </Text>
+          <Text fontType="p2" width={convertToResponsive(120, 160)}>
+            {graduationType === 'QUALIFICATION_EXAMINATION' ? '검정고시' : school}
+          </Text>
+          <Text fontType="p2" width={convertToResponsive(180, 240)}>
+            {FORM_TYPE_CATEGORY[type]}
+          </Text>
+        </Row>
+        <Row gap={48} justify-content="flex-end">
+          <Text fontType="p2" width={convertToResponsive(40, 60)}>
+            {status === 'SUBMITTED' ? '초안 제출' : '최종 제출'}
+          </Text>
+          <Text fontType="p2" width={convertToResponsive(40, 60)}>
+            승인
+          </Text>
           <Text
             fontType="p2"
             width={convertToResponsive(40, 60)}
-            color={getStatusColor(secondRoundPassed)}
+            color={getStatusColor(firstRoundPassed)}
           >
-            {getRoundResult(secondRoundPassed, status)}
+            {getRoundResult(firstRoundPassed)}
           </Text>
-        )}
-      </Row>
-    </TableItem>
+          <Text
+            fontType="p2"
+            width={convertToResponsive(40, 60)}
+            color={typeof totalScore !== 'number' ? color.gray600 : color.black}
+          >
+            {typeof totalScore !== 'number' ? '미정' : Number(totalScore.toFixed(3))}
+          </Text>
+        </Row>
+        <Row>
+          {isSecondRoundResultEditing ? (
+            <Dropdown
+              name="pass"
+              size="SMALL"
+              width={100}
+              value={secondRoundResult[id] || getRoundResult(secondRoundPassed, status)}
+              data={['합격', '불합격']}
+              onChange={handleSecondPassResultDropdownChange}
+            />
+          ) : (
+            <Text
+              fontType="p2"
+              width={convertToResponsive(40, 60)}
+              color={getStatusColor(secondRoundPassed)}
+            >
+              {getRoundResult(secondRoundPassed, status)}
+            </Text>
+          )}
+        </Row>
+      </TableItem>
+    </DirectButton>
   );
 };
 
 export default FormTableItem;
+
+const DirectButton = styled.button`
+  text-align: start;
+`;

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -1,4 +1,5 @@
 import { TableItem } from '@/components/common';
+import { ROUTES } from '@/constants/common/constant';
 import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
 import { useFormToPrintStore } from '@/store/form/formToPrint';
 import { useIsFormToPrintSelectingValueStore } from '@/store/form/isFormToPrintSelecting';
@@ -8,6 +9,7 @@ import type { Form, PassStatusType } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { color } from '@maru/design-system';
 import { CheckBox, Dropdown, Row, Text } from '@maru/ui';
+import { useRouter } from 'next/navigation';
 import type { ChangeEventHandler } from 'react';
 
 const FormTableItem = ({
@@ -22,6 +24,8 @@ const FormTableItem = ({
   firstRoundPassed,
   secondRoundPassed,
 }: Form) => {
+  const router = useRouter();
+
   const isSecondRoundResultEditing = useIsSecondRoundResultEditingValueStore();
   const [secondRoundResult, setSecondRoundResult] = useSecondRoundResultStore();
 
@@ -54,7 +58,7 @@ const FormTableItem = ({
   };
 
   return (
-    <TableItem key={id}>
+    <TableItem key={id} onClick={router.push(`${ROUTES.FORM}/${id}`)}>
       <Row gap={48}>
         {isFormToPrintSelecting ? (
           <CheckBox checked={formToPrint[id]} onChange={handleFormToPrintSelectChange} />

--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -5,6 +5,7 @@ export const KEY = {
   APPLICANT_GENDER_RATIO: 'useGenderRatio',
   APPLICANT_GRADUATED_SCHOOL: 'useGraduatedSchool',
   FORM_LIST: 'useFormList',
+  FORM_DETAIL: 'useFormDetail',
   SECOND_SCORE_FORMAT: 'useSecondScoreFormat',
   FORM_EXPORT_EXCEL: 'useFormExportExcel',
   FORM_EXPORT_ALL_ADMISSION_TICKET: 'useFormExportAllAdmissionTicket',

--- a/apps/admin/src/constants/form/constant.ts
+++ b/apps/admin/src/constants/form/constant.ts
@@ -54,3 +54,12 @@ export const EXPORT_EXCEL_TYPE = [
   '2차 전형 결과',
   '최종 합격자',
 ] as const;
+
+export const FORM_DETAIL_STEP_LIST = [
+  '지원자 정보',
+  '보호자 정보',
+  '출신학교 및 학력',
+  '전형',
+  '성적',
+  '자기소개서',
+] as const;

--- a/apps/admin/src/services/form/api.ts
+++ b/apps/admin/src/services/form/api.ts
@@ -7,6 +7,7 @@ import type {
   FormListType,
 } from '@/types/form/client';
 import type {
+  GetFormDetail,
   GetFormListRes,
   GetFormURLRes,
   PatchSecondRoundResultReq,
@@ -73,6 +74,12 @@ export const getAllAdmissionTicket = async () => {
     ...authorization(),
     responseType: 'blob',
   });
+
+  return data;
+};
+
+export const getFormDetail = async (id: number) => {
+  const { data } = await maru.get<GetFormDetail>(`/forms/${id}`, authorization());
 
   return data;
 };

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -2,6 +2,7 @@ import { KEY } from '@/constants/common/constant';
 import {
   getAllAdmissionTicket,
   getExportExcel,
+  getFormDetail,
   getFormList,
   getSecondScoreFormat,
 } from './api';
@@ -45,8 +46,17 @@ export const useExportExcelQuery = (exportExcelType: ExportExcelType) => {
 export const useExportAllAddmissionTicket = () => {
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.FORM_EXPORT_ALL_ADMISSION_TICKET],
-    queryFn: () => getAllAdmissionTicket(),
+    queryFn: getAllAdmissionTicket,
   });
 
   return { data, ...restQuery };
+};
+
+export const useFormDetailQuery = (id: number) => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.FORM_DETAIL, id],
+    queryFn: () => getFormDetail(id),
+  });
+
+  return { data: data?.data, ...restQuery };
 };

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -61,3 +61,81 @@ export interface FormListSortingType {
   type: FormType | null;
   sort: FormSort | null;
 }
+
+export interface FormDetail {
+  id: number;
+  examinationNumber: number;
+  applicant: UserInfo;
+  parent: ParentInfo;
+  education: EducationInfo;
+  grade: {
+    subjectList: Subject[];
+    attendance1: Attendance;
+    attendance2: Attendance;
+    attendance3: Attendance;
+    volunteerTime1: number;
+    volunteerTime2: number;
+    volunteerTime3: number;
+    certificateList: string[];
+  };
+  document: {
+    coverLetter: string;
+    statementOfPurpose: string;
+  };
+  formUrl: string;
+  type: FormType;
+  status: FormStatus;
+  changedToRegular: boolean;
+}
+
+export interface UserInfo {
+  identificationPictureUri: string;
+  name: string;
+  phoneNumber: string;
+  birthday: string;
+  gender: 'MALE' | 'FEMALE';
+}
+
+export interface ParentInfo {
+  name: string;
+  phoneNumber: string;
+  relation: string;
+  zoneCode: string;
+  address: string;
+  detailAddress: string;
+}
+
+export interface EducationInfo {
+  graduationType: GraduationType;
+  graduationYear: string;
+  schoolName: string;
+  schoolLocation: string;
+  schoolCode: string;
+  schoolPhoneNumber: string;
+  schoolAddress: string;
+  teacherName: string;
+  teacherMobilePhoneNumber: string;
+}
+
+export type AchievementLevel = 'A' | 'B' | 'C' | 'D' | 'E' | '-';
+
+export interface AchievementLevelsGroup {
+  subjectName: string;
+  achievementLevels: AchievementLevel[];
+  grades: number[];
+  semesters: number[];
+}
+
+export interface Subject {
+  grade: number;
+  semester: number;
+  subjectName: string;
+  achievementLevel: AchievementLevel;
+}
+
+export interface Attendance {
+  absenceCount: number;
+  latenessCount: number;
+  earlyLeaveCount: number;
+  classAbsenceCount: number;
+}

--- a/apps/admin/src/types/form/remote.ts
+++ b/apps/admin/src/types/form/remote.ts
@@ -1,4 +1,4 @@
-import type { Form } from './client';
+import type { Form, FormDetail } from './client';
 
 export interface GetFormListRes {
   dataList: Form[];
@@ -14,4 +14,8 @@ export interface GetFormURLRes {
 
 export interface PatchSecondRoundResultReq {
   formList: { formId: number; pass: boolean | null }[];
+}
+
+export interface GetFormDetail {
+  data: FormDetail;
 }


### PR DESCRIPTION
## 📄 Summary

> 어드민의 원서 상세조회 페이지의 원서 프로필과 네비게이션 바를 추가 했습니다.

<br>

## 🔨 Tasks

- 원서 상세조회 API 연동
- 원서 상세조회 프로필 추가
- 원서 상세조회 네비게이션 바 추가

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/55de9103-c797-430b-b1b8-e74cbc64f9f7)
원서 상세조회의 원서 상태는  
백엔드가 디자인의 해당 요소를 염두하지 않고 개발하였기에 때문에 백엔드의 API 수정 시 추가 할 예정입니다.