### PR TITLE
feat(admin): 원서 상세조회 지원자 정보 추가

### DIFF
--- a/apps/admin/src/components/common/DataBox/DataBox.tsx
+++ b/apps/admin/src/components/common/DataBox/DataBox.tsx
@@ -13,7 +13,7 @@ interface DataBoxProps {
 
 const DataBox = ({ label, data, lengthType = 'SHORT' }: DataBoxProps) => {
   return (
-    <StyledDataBox>
+    <StyledDataBox lengthType={lengthType}>
       <Text fontType="H4" color={color.gray900}>
         {label}
       </Text>
@@ -27,9 +27,9 @@ const DataBox = ({ label, data, lengthType = 'SHORT' }: DataBoxProps) => {
 };
 export default DataBox;
 
-const StyledDataBox = styled.div`
+const StyledDataBox = styled.div<{ lengthType: LengthType }>`
   ${flex({ flexDirection: 'column', alignItems: 'flex-start' })}
-  width: 604px;
+  width: ${(props) => (props.lengthType === 'SHORT' ? '100%' : 'fit-content')};
   min-width: 400px;
   padding: 24px;
   gap: 16px;
@@ -41,7 +41,7 @@ const StyledDataBox = styled.div`
 
 const DataUnderlineBox = styled.div<{ lengthType: LengthType }>`
   ${flex({ alignItems: 'flex-start' })}
-  width: ${(props) => (props.lengthType === 'SHORT' ? '360px' : '100%')};
+  width: ${(props) => (props.lengthType === 'SHORT' ? '60%' : '100%')};
   padding-bottom: 4px;
   border-bottom: 1px solid ${color.gray200};
 `;

--- a/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
@@ -1,0 +1,31 @@
+import { DataBox } from '@/components/common';
+import { Row } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { styled } from 'styled-components';
+
+
+
+const ApplicantInfo = () => {
+  return (
+    <StyledApplicantInfo>
+      {applicantData.map((item, index) => (
+        <GridItem key={index}>
+          <DataBox label={item.label} data={item.data} />
+        </GridItem>
+      ))}
+    </StyledApplicantInfo>
+  );
+};
+export default ApplicantInfo;
+
+const StyledApplicantInfo = styled.div`
+  ${flex({ flexDirection: 'column' })}
+  padding: 48px 0;
+  gap: 24px;
+`;
+
+const GridItem = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+`;

--- a/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
@@ -1,6 +1,8 @@
 import { DataBox } from '@/components/common';
-import { Loader } from '@maru/ui';
+import { color } from '@maru/design-system';
+import { Loader, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
+import Image from 'next/image';
 import { styled } from 'styled-components';
 
 interface ApplicantInfoProps {
@@ -31,6 +33,18 @@ const ApplicantInfo = ({ applicantData }: ApplicantInfoProps) => {
             <DataBox label={item.label} data={item.data} />
           </GridItem>
         ))}
+        <ProfileImageBox>
+          <Text fontType="H4" color={color.gray900}>
+            증명사진
+          </Text>
+          <ProfileImage
+            src={applicantData.profileImageUrl}
+            alt="profile-image"
+            width={280}
+            height={354}
+            style={{ objectFit: 'cover', objectPosition: 'top' }}
+          />
+        </ProfileImageBox>
       </GridContainer>
     </StyledApplicantInfo>
   );
@@ -50,3 +64,19 @@ const GridContainer = styled.div`
 `;
 
 const GridItem = styled.div``;
+
+const ProfileImageBox = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'flex-start' })}
+  width: 100%;
+  min-width: 400px;
+  padding: 24px;
+  gap: 16px;
+
+  border-radius: 12px;
+  border: 1px solid ${color.gray200};
+  background: ${color.white};
+`;
+
+const ProfileImage = styled(Image)`
+  background: ${color.gray100};
+`;

--- a/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
@@ -1,18 +1,37 @@
 import { DataBox } from '@/components/common';
-import { Row } from '@maru/ui';
+import { Loader } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { styled } from 'styled-components';
 
+interface ApplicantInfoProps {
+  applicantData?: {
+    name: string;
+    birthday: string;
+    gender: string;
+    phoneNumber: string;
+    profileImageUrl: string;
+  };
+}
 
+const ApplicantInfo = ({ applicantData }: ApplicantInfoProps) => {
+  if (!applicantData) return <Loader />;
 
-const ApplicantInfo = () => {
+  const applicantDetails = [
+    { label: '이름', data: applicantData.name },
+    { label: '생년월일', data: applicantData.birthday },
+    { label: '성별', data: applicantData.gender },
+    { label: '전화번호', data: applicantData.phoneNumber },
+  ];
+
   return (
     <StyledApplicantInfo>
-      {applicantData.map((item, index) => (
-        <GridItem key={index}>
-          <DataBox label={item.label} data={item.data} />
-        </GridItem>
-      ))}
+      <GridContainer>
+        {applicantDetails.map((item, index) => (
+          <GridItem key={index}>
+            <DataBox label={item.label} data={item.data} />
+          </GridItem>
+        ))}
+      </GridContainer>
     </StyledApplicantInfo>
   );
 };
@@ -24,8 +43,10 @@ const StyledApplicantInfo = styled.div`
   gap: 24px;
 `;
 
-const GridItem = styled.div`
+const GridContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 24px;
 `;
+
+const GridItem = styled.div``;

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -6,6 +6,8 @@ import { useState } from 'react';
 import { styled } from 'styled-components';
 import { useFormDetailDataDecomposition } from './formDetail.hooks';
 import Profile from './Profile/Profile';
+import { SwitchCase } from '@toss/react';
+import ApplicantInfo from './ApplicantInfo/ApplicantInfo';
 
 interface FormDetailProps {
   id: number;
@@ -14,7 +16,7 @@ interface FormDetailProps {
 const FormDetail = ({ id }: FormDetailProps) => {
   const [currentFormDetailStep, setCurrentFormDetailStep] = useState('지원자 정보');
 
-  const { profileData } = useFormDetailDataDecomposition(id);
+  const { profileData, applicantData } = useFormDetailDataDecomposition(id);
 
   return (
     <StyledFormDetail>
@@ -34,6 +36,12 @@ const FormDetail = ({ id }: FormDetailProps) => {
             </UnderlineButton>
           ))}
         </NavigationBar>
+        <SwitchCase
+          value={currentFormDetailStep}
+          caseBy={{
+            '지원자 정보': <ApplicantInfo applicantData={applicantData} />,
+          }}
+        />
       </Column>
     </StyledFormDetail>
   );

--- a/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
+++ b/apps/admin/src/components/form/FormDetail/Profile/Profile.tsx
@@ -54,11 +54,11 @@ const Profile = ({ profileData }: ProfileProps) => {
           {profileData.name}
         </Text>
         <Column gap={8}>
-          {profileDetails.map((detail, index) => (
+          {profileDetails.map((item, index) => (
             <Row key={index} gap={10}>
-              {detail.icon}
+              {item.icon}
               <Text fontType="p2" color={color.gray900}>
-                {detail.value}
+                {item.value}
               </Text>
             </Row>
           ))}

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -1,5 +1,6 @@
 import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
 import { useFormDetailQuery } from '@/services/form/queries';
+import { formatDate, formatPhoneNumber } from '@/utils';
 
 export const useFormDetailDataDecomposition = (id: number) => {
   const { data: formDetailData } = useFormDetailQuery(id);
@@ -19,5 +20,13 @@ export const useFormDetailDataDecomposition = (id: number) => {
         : '검정고시',
   };
 
-  return { profileData };
+  const applicantData = formDetailData && {
+    name: formDetailData.applicant.name,
+    birthday: formatDate.toShortDateTime(formDetailData.applicant.birthday),
+    gender: formDetailData.applicant.gender,
+    phoneNumber: formatPhoneNumber(formDetailData.applicant.phoneNumber),
+    profileImageUrl: formDetailData.applicant.identificationPictureUri,
+  };
+
+  return { profileData, applicantData };
 };

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -1,4 +1,4 @@
-import { FORM_TYPE_CATEGORY } from '@/constants/form/constant';
+import { FORM_TYPE_CATEGORY, GENDER } from '@/constants/form/constant';
 import { useFormDetailQuery } from '@/services/form/queries';
 import { formatDate, formatPhoneNumber } from '@/utils';
 
@@ -23,7 +23,7 @@ export const useFormDetailDataDecomposition = (id: number) => {
   const applicantData = formDetailData && {
     name: formDetailData.applicant.name,
     birthday: formatDate.toShortDateTime(formDetailData.applicant.birthday),
-    gender: formDetailData.applicant.gender,
+    gender: GENDER[formDetailData.applicant.gender],
     phoneNumber: formatPhoneNumber(formDetailData.applicant.phoneNumber),
     profileImageUrl: formDetailData.applicant.identificationPictureUri,
   };

--- a/apps/admin/src/constants/form/constant.ts
+++ b/apps/admin/src/constants/form/constant.ts
@@ -3,6 +3,7 @@ import type {
   FormSort,
   FormStatus,
   FormType,
+  Gender,
 } from '@/types/form/client';
 
 export const FORM_STATUS_CATEGORY: Record<FormStatus, string> = {
@@ -63,3 +64,8 @@ export const FORM_DETAIL_STEP_LIST = [
   '성적',
   '자기소개서',
 ] as const;
+
+const GENDER: Record<Gender, string> = {
+  MALE: '남자',
+  FEMALE: '여자',
+} as const;

--- a/apps/admin/src/constants/form/constant.ts
+++ b/apps/admin/src/constants/form/constant.ts
@@ -65,7 +65,7 @@ export const FORM_DETAIL_STEP_LIST = [
   '자기소개서',
 ] as const;
 
-const GENDER: Record<Gender, string> = {
+export const GENDER: Record<Gender, string> = {
   MALE: '남자',
   FEMALE: '여자',
 } as const;

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -88,12 +88,14 @@ export interface FormDetail {
   changedToRegular: boolean;
 }
 
+export type Gender = 'MALE' | 'FEMALE';
+
 export interface UserInfo {
   identificationPictureUri: string;
   name: string;
   phoneNumber: string;
   birthday: string;
-  gender: 'MALE' | 'FEMALE';
+  gender: Gender;
 }
 
 export interface ParentInfo {

--- a/apps/admin/src/utils/functions/formatDate.ts
+++ b/apps/admin/src/utils/functions/formatDate.ts
@@ -29,6 +29,15 @@ const formatDate = {
     return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
   },
 
+  toShortDateTime: (dateString: string) => {
+    const date = new Date(formatDate.normalizeDate(dateString));
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    return `${year}년 ${month}월 ${day}일`;
+  },
+
   toDayAndDateTime: (dateString: string) => {
     const date = new Date(formatDate.normalizeDate(dateString));
     const month = date.getMonth() + 1;


### PR DESCRIPTION
## 📄 Summary

> 원서 상세조회의 Navigation 중 지원자 정보를 추가했습니다.

<br>

## 🔨 Tasks

- 지원자 정보 관련 데이터 정제 후 자식 컴포넌트로 보냄
- 지원자 정보 데이터(이름, 전화번호, 성별, 생일) 동적으로 UI 렌더링
- 지원자 정보 증명사진 추가  

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/6af1f588-a2b9-4f77-87a4-7133584a7e1f)
