### PR TITLE
feat(user): 원서 작성 후 페이지 이동

### DIFF
--- a/apps/user/src/app/form/Grade/Certificate/Certificate.hook.ts
+++ b/apps/user/src/app/form/Grade/Certificate/Certificate.hook.ts
@@ -1,17 +1,25 @@
 import { useSaveFormMutation } from '@/services/form/mutations';
 import {
+  useCorrectStore,
   useFormValueStore,
   useSetFormGradeStepStore,
   useSetFormStepStore,
 } from '@/stores';
 
 export const useCTAButton = () => {
+  const [correct, setCorrect] = useCorrectStore();
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const setFormGradeStep = useSetFormGradeStepStore();
   const { saveFormMutate } = useSaveFormMutation();
 
   const handleNextStep = () => {
+    if (correct === true) {
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      setCorrect(false);
+    }
+
     setFormStep('자기소개서');
     saveFormMutate(form);
   };

--- a/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.hook.ts
+++ b/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.hook.ts
@@ -1,0 +1,18 @@
+import { useSetFormGradeStepStore, useSetFormStepStore } from '@/stores';
+import type { FormStep } from '@/types/form/client';
+
+export const useCTAButton = () => {
+  const setFormStep = useSetFormStepStore();
+  const setFormGradeStep = useSetFormGradeStepStore();
+
+  const handleCorrectGrade = () => {
+    setFormStep('성적입력');
+    setFormGradeStep('교과성적');
+  };
+
+  const handleCorrectForm = (step: FormStep) => {
+    setFormStep(step);
+  };
+
+  return { handleCorrectGrade, handleCorrectForm };
+};

--- a/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.hook.ts
+++ b/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.hook.ts
@@ -1,17 +1,24 @@
-import { useSetFormGradeStepStore, useSetFormStepStore } from '@/stores';
+import {
+  useSetCorrectStore,
+  useSetFormGradeStepStore,
+  useSetFormStepStore,
+} from '@/stores';
 import type { FormStep } from '@/types/form/client';
 
 export const useCTAButton = () => {
   const setFormStep = useSetFormStepStore();
   const setFormGradeStep = useSetFormGradeStepStore();
+  const setCorrect = useSetCorrectStore();
 
   const handleCorrectGrade = () => {
     setFormStep('성적입력');
     setFormGradeStep('교과성적');
+    setCorrect(true);
   };
 
   const handleCorrectForm = (step: FormStep) => {
     setFormStep(step);
+    setCorrect(true);
   };
 
   return { handleCorrectGrade, handleCorrectForm };

--- a/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.tsx
+++ b/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import CheckFormComplete from './CheckFormComplete/CheckFormComplete';
 import { useFormValueStore } from '@/stores';
+import { useCTAButton } from './CheckFormCompleteBox.hook';
 
 interface Props {
   applicantFilledCount: number;
@@ -18,6 +19,7 @@ const CheckFormCompleteBox = ({
   documentFilledCount,
 }: Props) => {
   const form = useFormValueStore();
+  const { handleCorrectGrade, handleCorrectForm } = useCTAButton();
 
   return (
     <StyledCheckFormCompleteBox>
@@ -25,11 +27,13 @@ const CheckFormCompleteBox = ({
         formStep="지원자 정보"
         maxCompleteOfNumber={5}
         completeOfNumber={applicantFilledCount}
+        onClick={() => handleCorrectForm('지원자정보')}
       />
       <CheckFormComplete
         formStep="보호자 정보"
         maxCompleteOfNumber={6}
         completeOfNumber={parentFilledCount}
+        onClick={() => handleCorrectForm('보호자정보')}
       />
       <CheckFormComplete
         formStep="출신학교 및 학력"
@@ -37,21 +41,25 @@ const CheckFormCompleteBox = ({
           form.education.graduationType === 'QUALIFICATION_EXAMINATION' ? +'2' : 9
         }
         completeOfNumber={educationFilledCount}
+        onClick={() => handleCorrectForm('출신학교및학력')}
       />
       <CheckFormComplete
         formStep="전형 선택"
         maxCompleteOfNumber={1}
         completeOfNumber={typeFilledCount}
+        onClick={() => handleCorrectForm('전형선택')}
       />
       <CheckFormComplete
         formStep="성적 입력"
         maxCompleteOfNumber={4}
         completeOfNumber={4}
+        onClick={handleCorrectGrade}
       />
       <CheckFormComplete
         formStep="자기소개서 및 학업계획서"
         maxCompleteOfNumber={2}
         completeOfNumber={documentFilledCount}
+        onClick={() => handleCorrectForm('자기소개서')}
       />
     </StyledCheckFormCompleteBox>
   );

--- a/apps/user/src/components/form/Contents/ApplicantInformationContent/ApplicantInformationContent.hook.ts
+++ b/apps/user/src/components/form/Contents/ApplicantInformationContent/ApplicantInformationContent.hook.ts
@@ -3,7 +3,12 @@ import { useUser } from '@/hooks';
 import { ApplicantSchema } from '@/schemas/ApplicantSchema';
 import { useSaveFormMutation } from '@/services/form/mutations';
 import { useSaveFormQuery } from '@/services/form/queries';
-import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/stores';
+import {
+  useCorrectStore,
+  useFormValueStore,
+  useSetFormStepStore,
+  useSetFormStore,
+} from '@/stores';
 import { formatDate } from '@/utils';
 import { useEffect, useState } from 'react';
 import type { ChangeEventHandler } from 'react';
@@ -11,6 +16,7 @@ import { z } from 'zod';
 
 export const useApplicantForm = () => {
   const form = useFormValueStore();
+  const [correct, setCorrect] = useCorrectStore();
   const setForm = useSetFormStore();
   const setFormStep = useSetFormStepStore();
   const { userData } = useUser();
@@ -62,6 +68,14 @@ export const useApplicantForm = () => {
   const handleNextStep = () => {
     if (!fileName || !mediaType || !fileSize) {
       return;
+    }
+
+    if (correct === true) {
+      ApplicantSchema.parse(form.applicant);
+      setErrors({});
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      setCorrect(false);
     }
 
     try {

--- a/apps/user/src/components/form/Contents/EducationContent/EducationContent.hook.ts
+++ b/apps/user/src/components/form/Contents/EducationContent/EducationContent.hook.ts
@@ -1,17 +1,18 @@
 import { useSetFormGradeStepStore } from './../../../../stores/form/formGradeStep';
 import { EducationSchema } from '@/schemas/EducationSchema';
 import { useSaveFormMutation } from '@/services/form/mutations';
-import { useFormStore, useSetFormStepStore } from '@/stores';
+import { useCorrectStore, useFormStore, useSetFormStepStore } from '@/stores';
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 import { z } from 'zod';
 
 export const useEducationForm = () => {
   const [form, setForm] = useFormStore();
+  const [correct, setCorrect] = useCorrectStore();
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
   const setFormStep = useSetFormStepStore();
   const setFormGradeStep = useSetFormGradeStepStore();
   const { saveFormMutate } = useSaveFormMutation();
-  const [errors, setErrors] = useState<Record<string, string[]>>({});
 
   const numberFiled = [
     'graduationYear',
@@ -38,6 +39,14 @@ export const useEducationForm = () => {
   };
 
   const handlePreviousStep = () => {
+    if (correct === true) {
+      EducationSchema.parse(form.education);
+      setErrors({});
+      setFormStep('보호자정보');
+      saveFormMutate(form);
+      setCorrect(false);
+    }
+
     try {
       EducationSchema.parse(form.education);
       setErrors({});

--- a/apps/user/src/components/form/Contents/GuardianInformationContent/GuardianInformationContent.hook.ts
+++ b/apps/user/src/components/form/Contents/GuardianInformationContent/GuardianInformationContent.hook.ts
@@ -1,11 +1,12 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 import { useSaveFormMutation } from '@/services/form/mutations';
-import { useFormStore, useSetFormStepStore } from '@/stores';
+import { useCorrectStore, useFormStore, useSetFormStepStore } from '@/stores';
 import { GuardianSchema } from '@/schemas/GuardianSchema';
 import { z } from 'zod';
 
 export const useGuardianForm = () => {
+  const [correct, setCorrect] = useCorrectStore();
   const [form, setForm] = useFormStore();
   const [errors, setErrors] = useState<Record<string, string[]>>({});
   const setFormStep = useSetFormStepStore();
@@ -32,6 +33,14 @@ export const useGuardianForm = () => {
   };
 
   const handleNextStep = () => {
+    if (correct === true) {
+      GuardianSchema.parse(form.parent);
+      setErrors({});
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      setCorrect(false);
+    }
+
     try {
       GuardianSchema.parse(form.parent);
       setErrors({});

--- a/apps/user/src/components/form/Contents/IntroductionContent/IntroductionContent.hook.ts
+++ b/apps/user/src/components/form/Contents/IntroductionContent/IntroductionContent.hook.ts
@@ -1,11 +1,17 @@
 import { IntroductionSchema } from '@/schemas/IntroductionSchema';
 import { useSaveFormMutation } from '@/services/form/mutations';
-import { useFormStore, useSetFormGradeStepStore, useSetFormStepStore } from '@/stores';
+import {
+  useCorrectStore,
+  useFormStore,
+  useSetFormGradeStepStore,
+  useSetFormStepStore,
+} from '@/stores';
 import { useState, type ChangeEventHandler } from 'react';
 import { z } from 'zod';
 
 export const useIntoductionForm = () => {
   const [form, setForm] = useFormStore();
+  const [correct, setCorrect] = useCorrectStore();
   const [errors, setErrors] = useState<Record<string, string[]>>({});
   const setFormStep = useSetFormStepStore();
   const setFormGradeStep = useSetFormGradeStepStore();
@@ -21,6 +27,14 @@ export const useIntoductionForm = () => {
   };
 
   const handleNextStep = () => {
+    if (correct === true) {
+      IntroductionSchema.parse(form.document);
+      setErrors({});
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      setCorrect(false);
+    }
+
     try {
       IntroductionSchema.parse(form.document);
       setErrors({});

--- a/apps/user/src/components/form/Contents/TypeContent/TypeContent.hook.ts
+++ b/apps/user/src/components/form/Contents/TypeContent/TypeContent.hook.ts
@@ -1,13 +1,25 @@
 import { useSaveFormMutation } from '@/services/form/mutations';
-import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/stores';
+import {
+  useCorrectStore,
+  useFormValueStore,
+  useSetFormStepStore,
+  useSetFormStore,
+} from '@/stores';
 import type { ChangeEventHandler } from 'react';
 
 export const useCTAButton = () => {
+  const [correct, setCorrect] = useCorrectStore();
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const { saveFormMutate } = useSaveFormMutation();
 
   const handleNextStep = () => {
+    if (correct === true) {
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      setCorrect(false);
+    }
+
     setFormStep('성적입력');
     saveFormMutate(form);
   };

--- a/apps/user/src/components/form/FormController/FormController.tsx
+++ b/apps/user/src/components/form/FormController/FormController.tsx
@@ -1,3 +1,4 @@
+import { useCorrectValueStore, useFormGradeStepValueStore } from '@/stores';
 import type { FormStep } from '@/types/form/client';
 import { Button } from '@maru/ui';
 import { flex } from '@maru/utils';
@@ -10,9 +11,18 @@ interface FormControllerProps {
 }
 
 const FormController = ({ onPrevious, onNext, step }: FormControllerProps) => {
+  const correct = useCorrectValueStore();
+  const formGradeStep = useFormGradeStepValueStore();
+
   return (
     <StyledControllerArea>
-      {step === '지원자정보' ? (
+      {step === '지원자정보' ||
+      (correct === true &&
+        (formGradeStep === '교과성적' ||
+          step === '보호자정보' ||
+          step === '자기소개서' ||
+          step === '전형선택' ||
+          step === '출신학교및학력')) ? (
         <Button styleType="PRIMARY" size="MEDIUM" width={150} onClick={onNext}>
           다음
         </Button>

--- a/apps/user/src/stores/form/correct.ts
+++ b/apps/user/src/stores/form/correct.ts
@@ -1,0 +1,10 @@
+import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
+const correctAtomState = atom({
+  key: 'correct',
+  default: false,
+});
+
+export const useCorrectStore = () => useRecoilState(correctAtomState);
+export const useCorrectValueStore = () => useRecoilValue(correctAtomState);
+export const useSetCorrectStore = () => useSetRecoilState(correctAtomState);

--- a/apps/user/src/stores/index.ts
+++ b/apps/user/src/stores/index.ts
@@ -51,3 +51,9 @@ export {
 } from './form/formDocument';
 
 export { useSignUpStore } from './user/signup';
+
+export {
+  useCorrectStore,
+  useCorrectValueStore,
+  useSetCorrectStore,
+} from './form/correct';


### PR DESCRIPTION
## 📄 Summary

> 원서 작성 후 초안작성완료 페이지에서 확인을 위해서 원서 페이지를 클릭하면 이동하고 다음 버튼을 누르면 초안작성완료 페이지로 이동하도록 했습니다.

<br>

## 🔨 Tasks

- recoil 전역 상태관리
- 클릭했을때 이동 페이지 수정

<br>

## 🙋🏻 More
