### PR TITLE
feat(admin): 원서 상세조회 성적 교과성적 추가

### DIFF
--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -12,6 +12,7 @@ import ParentInfo from './ParentInfo/ParentInfo';
 import EducationInfo from './EducationInfo/EducationInfo';
 import TypeInfo from './TypeInfo/TypeInfo';
 import type { FormDetailStep } from '@/types/form/client';
+import GradesInfo from './GradesInfo/GradesInfo';
 
 interface FormDetailProps {
   id: number;
@@ -49,6 +50,7 @@ const FormDetail = ({ id }: FormDetailProps) => {
             '보호자 정보': <ParentInfo parentData={parentData} />,
             '출신학교 및 학력': <EducationInfo educationData={educationData} />,
             전형: <TypeInfo typeData={typeData} />,
+            성적: <GradesInfo />,
           }}
         />
       </Column>

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -1,4 +1,4 @@
-import { FORM_DETAIL_STEP_LIST } from '@/constants/form/constant';
+import { FORM_DETAIL_FIELDS } from '@/constants/form/constant';
 import { color } from '@maru/design-system';
 import { Column, UnderlineButton } from '@maru/ui';
 import { flex } from '@maru/utils';
@@ -11,7 +11,7 @@ import ApplicantInfo from './ApplicantInfo/ApplicantInfo';
 import ParentInfo from './ParentInfo/ParentInfo';
 import EducationInfo from './EducationInfo/EducationInfo';
 import TypeInfo from './TypeInfo/TypeInfo';
-import type { FormDetailStep } from '@/types/form/client';
+import type { FormDetailField } from '@/types/form/client';
 import GradesInfo from './GradesInfo/GradesInfo';
 
 interface FormDetailProps {
@@ -19,8 +19,8 @@ interface FormDetailProps {
 }
 
 const FormDetail = ({ id }: FormDetailProps) => {
-  const [currentFormDetailStep, setCurrentFormDetailStep] =
-    useState<FormDetailStep>('지원자 정보');
+  const [currentFormDetailField, setCurrentFormDetailField] =
+    useState<FormDetailField>('지원자 정보');
 
   const { profileData, applicantData, parentData, educationData, typeData, gradesData } =
     useFormDetailDataDecomposition(id);
@@ -33,18 +33,18 @@ const FormDetail = ({ id }: FormDetailProps) => {
       </Column>
       <Column>
         <NavigationBar>
-          {FORM_DETAIL_STEP_LIST.map((formDetailStep, index) => (
+          {FORM_DETAIL_FIELDS.map((formDetailField) => (
             <UnderlineButton
-              key={`form-detail-step ${index}`}
-              active={formDetailStep === currentFormDetailStep}
-              onClick={() => setCurrentFormDetailStep(formDetailStep)}
+              key={formDetailField}
+              active={currentFormDetailField === formDetailField}
+              onClick={() => setCurrentFormDetailField(formDetailField)}
             >
-              {formDetailStep}
+              {formDetailField}
             </UnderlineButton>
           ))}
         </NavigationBar>
         <SwitchCase
-          value={currentFormDetailStep}
+          value={currentFormDetailField}
           caseBy={{
             '지원자 정보': <ApplicantInfo applicantData={applicantData} />,
             '보호자 정보': <ParentInfo parentData={parentData} />,

--- a/apps/admin/src/components/form/FormDetail/FormDetail.tsx
+++ b/apps/admin/src/components/form/FormDetail/FormDetail.tsx
@@ -22,7 +22,7 @@ const FormDetail = ({ id }: FormDetailProps) => {
   const [currentFormDetailStep, setCurrentFormDetailStep] =
     useState<FormDetailStep>('지원자 정보');
 
-  const { profileData, applicantData, parentData, educationData, typeData } =
+  const { profileData, applicantData, parentData, educationData, typeData, gradesData } =
     useFormDetailDataDecomposition(id);
 
   return (
@@ -50,7 +50,7 @@ const FormDetail = ({ id }: FormDetailProps) => {
             '보호자 정보': <ParentInfo parentData={parentData} />,
             '출신학교 및 학력': <EducationInfo educationData={educationData} />,
             전형: <TypeInfo typeData={typeData} />,
-            성적: <GradesInfo />,
+            성적: <GradesInfo gradesData={gradesData} />,
           }}
         />
       </Column>

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/Grade.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/Grade.tsx
@@ -1,4 +1,4 @@
-import { Subject } from '@/types/form/client';
+import type { Subject } from '@/types/form/client';
 import getAchievementLevelsGroupList from './grade.hook';
 import { Column } from '@maru/ui';
 import GradeHeader from './GradeHeader/GradeHeader';

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/Grade.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/Grade.tsx
@@ -1,0 +1,29 @@
+import { Subject } from '@/types/form/client';
+import getAchievementLevelsGroupList from './grade.hook';
+import { Column } from '@maru/ui';
+import GradeHeader from './GradeHeader/GradeHeader';
+import GradeItem from './GradeItem/GradeItem';
+
+interface GradeProps {
+  subjectList: Subject[];
+}
+
+const Grade = ({ subjectList }: GradeProps) => {
+  const achievementLevelsGroupList = getAchievementLevelsGroupList(subjectList);
+
+  return (
+    <Column>
+      <GradeHeader />
+      {achievementLevelsGroupList.map((item) => (
+        <GradeItem
+          subjectName={item.subjectName}
+          achievementLevel21={item.achievementLevels[0]}
+          achievementLevel22={item.achievementLevels[1]}
+          achievementLevel31={item.achievementLevels[2]}
+        />
+      ))}
+    </Column>
+  );
+};
+
+export default Grade;

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/GradeHeader/GradeHeader.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/GradeHeader/GradeHeader.tsx
@@ -1,0 +1,34 @@
+import { Column, Row, Th } from '@maru/ui';
+
+const GradeHeader = () => {
+  return (
+    <Row>
+      <Th width={123} height={100} borderTopLeftRadius={12}>
+        과목
+      </Th>
+      <Column>
+        <Th width={279} height={50}>
+          2학년
+        </Th>
+        <Row>
+          <Th styleType="SECONDARY" width="50%" height={50}>
+            1학기
+          </Th>
+          <Th styleType="SECONDARY" width="50%" height={50}>
+            2학기
+          </Th>
+        </Row>
+      </Column>
+      <Column>
+        <Th width={140} height={50} borderTopRightRadius={12}>
+          3학년
+        </Th>
+        <Th styleType="SECONDARY" width="100%" height={50}>
+          1학기
+        </Th>
+      </Column>
+    </Row>
+  );
+};
+
+export default GradeHeader;

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/GradeItem/GradeItem.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/GradeItem/GradeItem.tsx
@@ -20,13 +20,13 @@ const GradeItem = ({
         {subjectName}
       </Td>
       <Td width={140} height="100%">
-        <CellInput type="text" value={achievementLevel21} readOnly />
+        <CellInput type="text" value={achievementLevel21 || '미이수'} readOnly />
       </Td>
       <Td width={140} height="100%">
-        <CellInput type="text" value={achievementLevel22} readOnly />
+        <CellInput type="text" value={achievementLevel22 || '미이수'} readOnly />
       </Td>
       <Td width={140} height="100%">
-        <CellInput type="text" value={achievementLevel31} readOnly />
+        <CellInput type="text" value={achievementLevel31 || '미이수'} readOnly />
       </Td>
     </Row>
   );

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/GradeItem/GradeItem.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/GradeItem/GradeItem.tsx
@@ -1,0 +1,35 @@
+import type { AchievementLevel } from '@/types/form/client';
+import { CellInput, Row, Td } from '@maru/ui';
+
+interface GradeItemProps {
+  subjectName: string;
+  achievementLevel21: AchievementLevel;
+  achievementLevel22: AchievementLevel;
+  achievementLevel31: AchievementLevel;
+}
+
+const GradeItem = ({
+  subjectName,
+  achievementLevel21,
+  achievementLevel22,
+  achievementLevel31,
+}: GradeItemProps) => {
+  return (
+    <Row height={64}>
+      <Td styleType="SECONDARY" width={123} height="100%">
+        {subjectName}
+      </Td>
+      <Td width={140} height="100%">
+        <CellInput type="text" value={achievementLevel21} readOnly />
+      </Td>
+      <Td width={140} height="100%">
+        <CellInput type="text" value={achievementLevel22} readOnly />
+      </Td>
+      <Td width={140} height="100%">
+        <CellInput type="text" value={achievementLevel31} readOnly />
+      </Td>
+    </Row>
+  );
+};
+
+export default GradeItem;

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/grade.hook.ts
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Grade/grade.hook.ts
@@ -1,0 +1,48 @@
+import type { AchievementLevelsGroup, Subject } from '@/types/form/client';
+
+const getAchievementLevelsGroupList = (
+  subjectList?: Subject[]
+): AchievementLevelsGroup[] => {
+  if (!subjectList || subjectList.length === 0) return [];
+
+  return subjectList.reduce((acc: AchievementLevelsGroup[], cur) => {
+    const existingSubject = acc.find(
+      (subject) => subject.subjectName === cur.subjectName
+    );
+
+    const indexMap: Record<string, number> = {
+      '2-1': 0,
+      '2-2': 1,
+      '3-1': 2,
+    };
+
+    const index = indexMap[`${cur.grade}-${cur.semester}`];
+
+    if (index === undefined) {
+      return acc;
+    }
+
+    if (existingSubject) {
+      existingSubject.achievementLevels[index] = cur.achievementLevel;
+      existingSubject.grades[index] = cur.grade;
+      existingSubject.semesters[index] = cur.semester;
+    } else {
+      const newSubject: AchievementLevelsGroup = {
+        subjectName: cur.subjectName,
+        achievementLevels: [],
+        grades: [],
+        semesters: [],
+      };
+
+      newSubject.achievementLevels[index] = cur.achievementLevel;
+      newSubject.grades[index] = cur.grade;
+      newSubject.semesters[index] = cur.semester;
+
+      acc.push(newSubject);
+    }
+
+    return acc;
+  }, []);
+};
+
+export default getAchievementLevelsGroupList;

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -1,12 +1,21 @@
 import { SideMenu } from '@/components/common';
 import { GRADES_FIELDS } from '@/constants/form/constant';
-import { Column } from '@maru/ui';
+import { Column, Loader } from '@maru/ui';
 import { SwitchCase } from '@toss/react';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 import Grade from './Grade/Grade';
+import { Subject } from '@/types/form/client';
 
-const GradesInfo = () => {
+interface GradesInfoProps {
+  gradesData?: {
+    grade: Subject[];
+  };
+}
+
+const GradesInfo = ({ gradesData }: GradesInfoProps) => {
+  if (!gradesData) return <Loader />;
+
   const [currentGradeField, setCurrentGradeField] = useState('교과 성적');
 
   return (
@@ -25,7 +34,7 @@ const GradesInfo = () => {
       <SwitchCase
         value={currentGradeField}
         caseBy={{
-          '교과 성적': <Grade subjectList={[]} />,
+          '교과 성적': <Grade subjectList={gradesData.grade} />,
         }}
       />
     </StyledGradesInfo>

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -5,7 +5,7 @@ import { SwitchCase } from '@toss/react';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 import Grade from './Grade/Grade';
-import { Subject } from '@/types/form/client';
+import type { Subject } from '@/types/form/client';
 
 interface GradesInfoProps {
   gradesData?: {

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -1,0 +1,35 @@
+import { SideMenu } from '@/components/common';
+import { GRADES_FIELDS } from '@/constants/form/constant';
+import { Column } from '@maru/ui';
+import { SwitchCase } from '@toss/react';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+const GradesInfo = () => {
+  const [currentGradeField, setCurrentGradeField] = useState('교과 성적');
+
+  return (
+    <StyledGradesInfo>
+      <Column gap={10}>
+        {GRADES_FIELDS.map((gradeField) => (
+          <SideMenu
+            key={gradeField}
+            isActive={currentGradeField === gradeField}
+            onClick={() => setCurrentGradeField(gradeField)}
+          >
+            {gradeField}
+          </SideMenu>
+        ))}
+      </Column>
+      <SwitchCase value={currentGradeField} caseBy={{}} />
+    </StyledGradesInfo>
+  );
+};
+export default GradesInfo;
+
+const StyledGradesInfo = styled.div`
+  display: flex;
+  gap: 48px;
+  width: 100%;
+  padding: 48px 0;
+`;

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -4,6 +4,7 @@ import { Column } from '@maru/ui';
 import { SwitchCase } from '@toss/react';
 import { useState } from 'react';
 import { styled } from 'styled-components';
+import Grade from './Grade/Grade';
 
 const GradesInfo = () => {
   const [currentGradeField, setCurrentGradeField] = useState('교과 성적');
@@ -21,7 +22,12 @@ const GradesInfo = () => {
           </SideMenu>
         ))}
       </Column>
-      <SwitchCase value={currentGradeField} caseBy={{}} />
+      <SwitchCase
+        value={currentGradeField}
+        caseBy={{
+          '교과 성적': <Grade subjectList={[]} />,
+        }}
+      />
     </StyledGradesInfo>
   );
 };

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -14,9 +14,9 @@ interface GradesInfoProps {
 }
 
 const GradesInfo = ({ gradesData }: GradesInfoProps) => {
-  if (!gradesData) return <Loader />;
-
   const [currentGradeField, setCurrentGradeField] = useState('교과 성적');
+
+  if (!gradesData) return <Loader />;
 
   return (
     <StyledGradesInfo>

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -65,5 +65,9 @@ export const useFormDetailDataDecomposition = (id: number) => {
       ? FORM_TYPE_CATEGORY[formDetailData.type]
       : '전형 정보 없음';
 
-  return { profileData, applicantData, parentData, educationData, typeData };
+  const gradesData = formDetailData && {
+    grade: formDetailData.grade.subjectList || [],
+  };
+
+  return { profileData, applicantData, parentData, educationData, typeData, gradesData };
 };

--- a/apps/admin/src/constants/form/constant.ts
+++ b/apps/admin/src/constants/form/constant.ts
@@ -76,3 +76,5 @@ export const GRADUATION_TYPE_VALUE: Record<GraduationType, string> = {
   EXPECTED: '졸업 예정',
   GRADUATED: '졸업',
 } as const;
+
+export const GRADES_FIELDS = ['교과 성적', '출결 상황', '봉사 시간', '자격증'] as const;

--- a/apps/admin/src/constants/form/constant.ts
+++ b/apps/admin/src/constants/form/constant.ts
@@ -57,7 +57,7 @@ export const EXPORT_EXCEL_TYPE = [
   '최종 합격자',
 ] as const;
 
-export const FORM_DETAIL_STEP_LIST = [
+export const FORM_DETAIL_FIELDS = [
   '지원자 정보',
   '보호자 정보',
   '출신학교 및 학력',

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -142,7 +142,7 @@ export interface Attendance {
   classAbsenceCount: number;
 }
 
-export type FormDetailStep =
+export type FormDetailField =
   | '지원자 정보'
   | '보호자 정보'
   | '출신학교 및 학력'

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -123,9 +123,9 @@ export type AchievementLevel = 'A' | 'B' | 'C' | 'D' | 'E' | '-';
 
 export interface AchievementLevelsGroup {
   subjectName: string;
-  achievementLevels: AchievementLevel[];
   grades: number[];
   semesters: number[];
+  achievementLevels: AchievementLevel[];
 }
 
 export interface Subject {


### PR DESCRIPTION
## 📄 Summary

> 원서 상세조회의 성적 중 교과성적을 추가했습니다.

<br>

## 🔨 Tasks

- SwitchCase 이용한 SideMenu 추가
- 원서 상세조회 성적 추가
- 성적 교과성적 추가
- 과목에 따른 학년과 학기 성적 리스트 추가

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/deb71c9e-fca3-4112-a81e-6ee94973bf7a)
