### PR TITLE
feat(admin): 원서 상세조회 성적 출결상황 추가

### DIFF
--- a/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
@@ -1,7 +1,7 @@
 import { Attendance } from '@/types/form/client';
 import { CellInput, Column, Row, Td, Th } from '@maru/ui';
 
-interface AttendanceProps {
+interface AttendanceStatusProps {
   attendanceRecords: {
     attendance1: Attendance;
     attendance2: Attendance;
@@ -9,7 +9,7 @@ interface AttendanceProps {
   };
 }
 
-const AttendanceStatus = ({ attendanceRecords }: AttendanceProps) => {
+const AttendanceStatus = ({ attendanceRecords }: AttendanceStatusProps) => {
   const attendanceData = [
     { gradeLabel: '1학년', data: attendanceRecords.attendance1 },
     { gradeLabel: '2학년', data: attendanceRecords.attendance2 },

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
@@ -1,4 +1,5 @@
 import { Attendance } from '@/types/form/client';
+import { convertToResponsive } from '@/utils';
 import { CellInput, Column, Row, Td, Th } from '@maru/ui';
 
 interface AttendanceStatusProps {
@@ -16,22 +17,24 @@ const AttendanceStatus = ({ attendanceRecords }: AttendanceStatusProps) => {
     { gradeLabel: '3학년', data: attendanceRecords.attendance3 },
   ];
 
+  const responsiveWidth = convertToResponsive(80, 140);
+
   return (
     <Column>
       <Row>
-        <Th width={140} height={56} borderTopLeftRadius={12}>
+        <Th width={responsiveWidth} height={56} borderTopLeftRadius={12}>
           학년
         </Th>
-        <Th width={140} height={56}>
+        <Th width={responsiveWidth} height={56}>
           미인정 결석
         </Th>
-        <Th width={140} height={56}>
+        <Th width={responsiveWidth} height={56}>
           미인정 지각
         </Th>
-        <Th width={140} height={56}>
+        <Th width={responsiveWidth} height={56}>
           미인정 조퇴
         </Th>
-        <Th width={140} height={56} borderTopRightRadius={12}>
+        <Th width={responsiveWidth} height={56} borderTopRightRadius={12}>
           미인정 결과
         </Th>
       </Row>
@@ -39,23 +42,23 @@ const AttendanceStatus = ({ attendanceRecords }: AttendanceStatusProps) => {
         <Row key={index}>
           <Td
             styleType="SECONDARY"
-            width={140}
+            width={responsiveWidth}
             height={56}
             borderBottomLeftRadius={index === attendanceData.length - 1 ? 12 : undefined}
           >
             {attendance.gradeLabel}
           </Td>
-          <Td width={140} height={56}>
+          <Td width={responsiveWidth} height={56}>
             <CellInput value={attendance.data?.absenceCount} readOnly />
           </Td>
-          <Td width={140} height={56}>
+          <Td width={responsiveWidth} height={56}>
             <CellInput value={attendance.data?.latenessCount} readOnly />
           </Td>
-          <Td width={140} height={56}>
+          <Td width={responsiveWidth} height={56}>
             <CellInput value={attendance.data?.earlyLeaveCount} readOnly />
           </Td>
           <Td
-            width={140}
+            width={responsiveWidth}
             height={56}
             borderBottomRightRadius={index === attendanceData.length - 1 ? 12 : undefined}
           >

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
@@ -1,0 +1,70 @@
+import { Attendance } from '@/types/form/client';
+import { CellInput, Column, Row, Td, Th } from '@maru/ui';
+
+interface AttendanceProps {
+  attendanceRecords: {
+    attendance1: Attendance;
+    attendance2: Attendance;
+    attendance3: Attendance;
+  };
+}
+
+const AttendanceStatus = ({ attendanceRecords }: AttendanceProps) => {
+  const attendanceData = [
+    { gradeLabel: '1학년', data: attendanceRecords.attendance1 },
+    { gradeLabel: '2학년', data: attendanceRecords.attendance2 },
+    { gradeLabel: '3학년', data: attendanceRecords.attendance3 },
+  ];
+
+  return (
+    <Column>
+      <Row>
+        <Th width={140} height={56} borderTopLeftRadius={12}>
+          학년
+        </Th>
+        <Th width={140} height={56}>
+          미인정 결석
+        </Th>
+        <Th width={140} height={56}>
+          미인정 지각
+        </Th>
+        <Th width={140} height={56}>
+          미인정 조퇴
+        </Th>
+        <Th width={140} height={56} borderTopRightRadius={12}>
+          미인정 결과
+        </Th>
+      </Row>
+      {attendanceData.map((attendance, index) => (
+        <Row key={index}>
+          <Td
+            styleType="SECONDARY"
+            width={140}
+            height={56}
+            borderBottomLeftRadius={index === attendanceData.length - 1 ? 12 : undefined}
+          >
+            {attendance.gradeLabel}
+          </Td>
+          <Td width={140} height={56}>
+            <CellInput value={attendance.data?.absenceCount} readOnly />
+          </Td>
+          <Td width={140} height={56}>
+            <CellInput value={attendance.data?.latenessCount} readOnly />
+          </Td>
+          <Td width={140} height={56}>
+            <CellInput value={attendance.data?.earlyLeaveCount} readOnly />
+          </Td>
+          <Td
+            width={140}
+            height={56}
+            borderBottomRightRadius={index === attendanceData.length - 1 ? 12 : undefined}
+          >
+            <CellInput value={attendance.data?.classAbsenceCount} readOnly />
+          </Td>
+        </Row>
+      ))}
+    </Column>
+  );
+};
+
+export default AttendanceStatus;

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
@@ -1,4 +1,4 @@
-import { Attendance } from '@/types/form/client';
+import type { Attendance } from '@/types/form/client';
 import { convertToResponsive } from '@/utils';
 import { CellInput, Column, Row, Td, Th } from '@maru/ui';
 

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/AttendanceStatus/AttendanceStatus.tsx
@@ -3,18 +3,14 @@ import { convertToResponsive } from '@/utils';
 import { CellInput, Column, Row, Td, Th } from '@maru/ui';
 
 interface AttendanceStatusProps {
-  attendanceRecords: {
-    attendance1: Attendance;
-    attendance2: Attendance;
-    attendance3: Attendance;
-  };
+  attendanceList: Attendance[];
 }
 
-const AttendanceStatus = ({ attendanceRecords }: AttendanceStatusProps) => {
+const AttendanceStatus = ({ attendanceList }: AttendanceStatusProps) => {
   const attendanceData = [
-    { gradeLabel: '1학년', data: attendanceRecords.attendance1 },
-    { gradeLabel: '2학년', data: attendanceRecords.attendance2 },
-    { gradeLabel: '3학년', data: attendanceRecords.attendance3 },
+    { gradeLabel: '1학년', data: attendanceList[0] },
+    { gradeLabel: '2학년', data: attendanceList[1] },
+    { gradeLabel: '3학년', data: attendanceList[2] },
   ];
 
   const responsiveWidth = convertToResponsive(80, 140);

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -5,11 +5,17 @@ import { SwitchCase } from '@toss/react';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 import Grade from './Grade/Grade';
-import type { Subject } from '@/types/form/client';
+import type { Attendance, Subject } from '@/types/form/client';
+import AttendanceStatus from './AttendanceStatus/AttendanceStatus';
 
 interface GradesInfoProps {
   gradesData?: {
-    grade: Subject[];
+    gradeData: Subject[];
+    attendanceData: {
+      attendance1: Attendance;
+      attendance2: Attendance;
+      attendance3: Attendance;
+    };
   };
 }
 
@@ -34,7 +40,8 @@ const GradesInfo = ({ gradesData }: GradesInfoProps) => {
       <SwitchCase
         value={currentGradeField}
         caseBy={{
-          '교과 성적': <Grade subjectList={gradesData.grade} />,
+          '교과 성적': <Grade subjectList={gradesData.gradeData} />,
+          '출결 상황': <AttendanceStatus attendanceRecords={gradesData.attendanceData} />,
         }}
       />
     </StyledGradesInfo>

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -11,11 +11,7 @@ import AttendanceStatus from './AttendanceStatus/AttendanceStatus';
 interface GradesInfoProps {
   gradesData?: {
     gradeData: Subject[];
-    attendanceData: {
-      attendance1: Attendance;
-      attendance2: Attendance;
-      attendance3: Attendance;
-    };
+    attendanceData: Attendance[];
   };
 }
 
@@ -41,7 +37,7 @@ const GradesInfo = ({ gradesData }: GradesInfoProps) => {
         value={currentGradeField}
         caseBy={{
           '교과 성적': <Grade subjectList={gradesData.gradeData} />,
-          '출결 상황': <AttendanceStatus attendanceRecords={gradesData.attendanceData} />,
+          '출결 상황': <AttendanceStatus attendanceList={gradesData.attendanceData} />,
         }}
       />
     </StyledGradesInfo>

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -67,11 +67,11 @@ export const useFormDetailDataDecomposition = (id: number) => {
 
   const gradesData = formDetailData && {
     gradeData: formDetailData.grade.subjectList || [],
-    attendanceData: {
-      attendance1: formDetailData.grade.attendance1,
-      attendance2: formDetailData.grade.attendance2,
-      attendance3: formDetailData.grade.attendance3,
-    },
+    attendanceData: [
+      formDetailData.grade.attendance1,
+      formDetailData.grade.attendance2,
+      formDetailData.grade.attendance3,
+    ],
   };
 
   return { profileData, applicantData, parentData, educationData, typeData, gradesData };

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -66,7 +66,12 @@ export const useFormDetailDataDecomposition = (id: number) => {
       : '전형 정보 없음';
 
   const gradesData = formDetailData && {
-    grade: formDetailData.grade.subjectList || [],
+    gradeData: formDetailData.grade.subjectList || [],
+    attendanceData: {
+      attendance1: formDetailData.grade.attendance1,
+      attendance2: formDetailData.grade.attendance2,
+      attendance3: formDetailData.grade.attendance3,
+    },
   };
 
   return { profileData, applicantData, parentData, educationData, typeData, gradesData };


### PR DESCRIPTION
## 📄 Summary

> 원서 상세조회의 성적 중 출결상황을 추가했습니다.

<br>

## 🔨 Tasks

- 성적 출결상황 추가
- 반응형 넓이로 출결상황 테이블 크기 제어
- attendance 리스트 데이터로 동적 UI 렌더링

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/aba29bdd-22df-4e23-9c27-1e54ffee467a)
