### PR TITLE
feat(admin): 원서 상세조회 성적 봉사시간 추가

### DIFF
--- a/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/GradesInfo.tsx
@@ -7,11 +7,13 @@ import { styled } from 'styled-components';
 import Grade from './Grade/Grade';
 import type { Attendance, Subject } from '@/types/form/client';
 import AttendanceStatus from './AttendanceStatus/AttendanceStatus';
+import Volunteer from './Volunteer/Volunteer';
 
 interface GradesInfoProps {
   gradesData?: {
     gradeData: Subject[];
     attendanceData: Attendance[];
+    volunteerData: number[];
   };
 }
 
@@ -38,6 +40,7 @@ const GradesInfo = ({ gradesData }: GradesInfoProps) => {
         caseBy={{
           '교과 성적': <Grade subjectList={gradesData.gradeData} />,
           '출결 상황': <AttendanceStatus attendanceList={gradesData.attendanceData} />,
+          '봉사 시간': <Volunteer VolunteerList={gradesData.volunteerData} />,
         }}
       />
     </StyledGradesInfo>

--- a/apps/admin/src/components/form/FormDetail/GradesInfo/Volunteer/Volunteer.tsx
+++ b/apps/admin/src/components/form/FormDetail/GradesInfo/Volunteer/Volunteer.tsx
@@ -1,0 +1,56 @@
+import { color, font } from '@maru/design-system';
+import { CellInput, Column, Row, Td, Th } from '@maru/ui';
+import { styled } from 'styled-components';
+
+interface VolunteerProps {
+  VolunteerList: number[];
+}
+
+const Volunteer = ({ VolunteerList }: VolunteerProps) => {
+  const volunteerData = [
+    { gradeLabel: '1학년', time: VolunteerList[0] },
+    { gradeLabel: '2학년', time: VolunteerList[1] },
+    { gradeLabel: '3학년', time: VolunteerList[2] },
+  ];
+
+  return (
+    <Column>
+      <Row>
+        <Th borderTopLeftRadius={12} width={162} height={56}>
+          학년
+        </Th>
+        <Th borderTopRightRadius={12} width={318} height={56}>
+          봉사시간
+        </Th>
+      </Row>
+      {volunteerData.map((volunteer, index) => (
+        <Row key={index}>
+          <Td
+            width={162}
+            height={56}
+            styleType="SECONDARY"
+            borderBottomLeftRadius={index === volunteerData.length - 1 ? 12 : undefined}
+          >
+            {volunteer.gradeLabel}
+          </Td>
+          <Td
+            width={318}
+            height={56}
+            borderBottomRightRadius={index === volunteerData.length - 1 ? 12 : undefined}
+          >
+            <CellInput value={volunteer.time} readOnly />
+            <Hour>시간</Hour>
+          </Td>
+        </Row>
+      ))}
+    </Column>
+  );
+};
+
+export default Volunteer;
+
+const Hour = styled.p`
+  ${font.p2}
+  color: ${color.gray900};
+  margin-left: 8px;
+`;

--- a/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
+++ b/apps/admin/src/components/form/FormDetail/formDetail.hooks.ts
@@ -72,6 +72,11 @@ export const useFormDetailDataDecomposition = (id: number) => {
       formDetailData.grade.attendance2,
       formDetailData.grade.attendance3,
     ],
+    volunteerData: [
+      formDetailData.grade.volunteerTime1,
+      formDetailData.grade.volunteerTime2,
+      formDetailData.grade.volunteerTime3,
+    ],
   };
 
   return { profileData, applicantData, parentData, educationData, typeData, gradesData };


### PR DESCRIPTION
## 📄 Summary

> 원서 상세조회의 성적 중 봉사시간을 추가했습니다.

<br>

## 🔨 Tasks

- 성적 봉사시간 추가
- volunteer 리스트 데이터로 동적 UI 렌더링

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/7ddd5b83-8e8a-4138-a783-13536b98b06b)
