### PR TITLE
feat(admin): 원서 관리 리스트 학생 이름 마스킹

### DIFF
--- a/apps/admin/src/app/Login.hooks.ts
+++ b/apps/admin/src/app/Login.hooks.ts
@@ -1,17 +1,13 @@
-import { ROUTES } from '@/constants/common/constant';
 import { useLoginAdminMutation } from '@/services/auth/mutations';
 import type { PostLoginAuthReq } from '@/types/auth/remote';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import type { ChangeEvent } from 'react';
 
 export const useLoginAction = (loginAdminData: PostLoginAuthReq) => {
-  const router = useRouter();
   const { loginAdminMutate } = useLoginAdminMutation(loginAdminData);
 
   const handleLogin = () => {
     loginAdminMutate();
-    router.push(ROUTES.FORM);
   };
 
   return { handleLogin };

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -6,11 +6,11 @@ import { useIsFormToPrintSelectingValueStore } from '@/store/form/isFormToPrintS
 import { useIsSecondRoundResultEditingValueStore } from '@/store/form/isSecondRoundResultEditing';
 import { useSecondRoundResultStore } from '@/store/form/secondRoundResult';
 import type { Form, PassStatusType } from '@/types/form/client';
-import { convertToResponsive } from '@/utils';
+import { convertToResponsive, maskName } from '@/utils';
 import { color } from '@maru/design-system';
 import { CheckBox, Dropdown, Row, Text } from '@maru/ui';
 import { useRouter } from 'next/navigation';
-import type { ChangeEventHandler } from 'react';
+import { ChangeEventHandler, useState } from 'react';
 import { styled } from 'styled-components';
 
 const FormTableItem = ({
@@ -29,6 +29,8 @@ const FormTableItem = ({
 
   const isSecondRoundResultEditing = useIsSecondRoundResultEditingValueStore();
   const [secondRoundResult, setSecondRoundResult] = useSecondRoundResultStore();
+
+  const [isHovered, setIsHovered] = useState(false);
 
   const handleSecondPassResultDropdownChange = (value: string) => {
     setSecondRoundResult((prev) => ({
@@ -69,6 +71,8 @@ const FormTableItem = ({
         cursor: isDisabled ? 'default' : 'pointer',
       }}
       onClick={handleMoveFormDetailPage}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <TableItem key={id}>
         <Row gap={48}>
@@ -82,7 +86,7 @@ const FormTableItem = ({
             {examinationNumber}
           </Text>
           <Text fontType="p2" width={convertToResponsive(40, 60)}>
-            {name}
+            {isHovered ? name : maskName(name)}
           </Text>
           <Text fontType="p2" width={convertToResponsive(120, 160)}>
             {graduationType === 'QUALIFICATION_EXAMINATION' ? '검정고시' : school}

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -10,7 +10,8 @@ import { convertToResponsive, maskName } from '@/utils';
 import { color } from '@maru/design-system';
 import { CheckBox, Dropdown, Row, Text } from '@maru/ui';
 import { useRouter } from 'next/navigation';
-import { ChangeEventHandler, useState } from 'react';
+import type { ChangeEventHandler } from 'react';
+import { useState } from 'react';
 import { styled } from 'styled-components';
 
 const FormTableItem = ({

--- a/apps/admin/src/services/auth/mutations.ts
+++ b/apps/admin/src/services/auth/mutations.ts
@@ -27,7 +27,7 @@ export const useLoginAdminMutation = ({ phoneNumber, password }: PostLoginAuthRe
     onSuccess: (res: AxiosResponse) => {
       const { accessToken, refreshToken } = res.data;
       saveTokens(accessToken, refreshToken);
-      router.replace(ROUTES.MAIN);
+      router.replace(ROUTES.FORM);
     },
     onError: handleError,
   });

--- a/apps/admin/src/services/form/mutations.ts
+++ b/apps/admin/src/services/form/mutations.ts
@@ -11,7 +11,7 @@ import { KEY } from '@/constants/common/constant';
 import type { PatchSecondRoundResultReq } from '@/types/form/remote';
 import { useSetIsSecondRoundResultEditingStore } from '@/store/form/isSecondRoundResultEditing';
 import { useSetSecondRoundResultStore } from '@/store/form/secondRoundResult';
-import isPopupBlocked from '@/utils/functions/isPopupBlocked';
+import { isPopupBlocked } from '@/utils';
 
 export const useUploadSecondScoreFormatMutation = (handleCloseModal: () => void) => {
   const { handleError } = useApiError();

--- a/apps/admin/src/utils/functions/maskName.ts
+++ b/apps/admin/src/utils/functions/maskName.ts
@@ -1,0 +1,11 @@
+const maskName = (name: string): string => {
+  if (name.length === 1) return name;
+  if (name.length === 2) {
+    return name[0] + '*';
+  }
+
+  const masked = '*'.repeat(name.length - 2);
+  return name[0] + masked + name[name.length - 1];
+};
+
+export default maskName;

--- a/apps/admin/src/utils/index.ts
+++ b/apps/admin/src/utils/index.ts
@@ -3,3 +3,4 @@ export { default as formatDate } from './functions/formatDate';
 export { default as formatPhoneNumber } from './functions/formatPhoneNumber';
 export { default as convertToResponsive } from './functions/convertToResponsive';
 export { default as maskName } from './functions/maskName';
+export { default as isPopupBlocked } from './functions/isPopupBlocked';

--- a/apps/admin/src/utils/index.ts
+++ b/apps/admin/src/utils/index.ts
@@ -2,3 +2,4 @@ export { default as resizeTextarea } from './functions/resizeTextarea';
 export { default as formatDate } from './functions/formatDate';
 export { default as formatPhoneNumber } from './functions/formatPhoneNumber';
 export { default as convertToResponsive } from './functions/convertToResponsive';
+export { default as maskName } from './functions/maskName';


### PR DESCRIPTION
## 📄 Summary

> 현재 원서 관리는 학생 이름이 "홍길동" 일 경우 "홍길동" 석자가 모두 보이게 됩니다.
이 때문에 누군가 마루 어드민 원서 관리 리스트를 볼 경우 단시간 내에 여러 사람의 이름의 정보가 탈취 되게 됩니다.
그렇기 때문에 원서 관리 리스트에서는 "홍*동" 처리를 하고, 원서 상세에서만 이름을 조회할 수 있게 변경했습니다.

<br>

## 🔨 Tasks

- 원서 관리 리스트 이름 마스킹(*처리)
- 호버 시에는 이름 원문

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/ea334fc6-22b5-45e3-a683-094f661507ec)
