### PR TITLE
fix(admin): 어드민 파일 업로드 안되는 문제 해결

### DIFF
--- a/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
+++ b/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
@@ -19,7 +19,7 @@ const SecondScoreUploader = ({ isOpen }: SecondScoreUploaderProps) => {
     if (isOpen && uploadedFile) {
       setUploadedFile(null);
     }
-  }, [isOpen, uploadedFile, setUploadedFile]);
+  }, [isOpen, setUploadedFile]);
 
   const handleUploadCancelButtonClick = () => {
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
+++ b/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
@@ -33,12 +33,17 @@ const SecondScoreUploader = ({ isOpen }: SecondScoreUploaderProps) => {
 
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsDragging(false);
 
     const droppedFile = e.dataTransfer.files[0];
 
     if (!droppedFile) return;
     setUploadedFile(droppedFile);
+  };
+
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
   };
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -52,7 +57,7 @@ const SecondScoreUploader = ({ isOpen }: SecondScoreUploaderProps) => {
     <StyledSecondScoreUploader
       onDragEnter={(e) => handleDragState(e, true)}
       onDragLeave={(e) => handleDragState(e, false)}
-      onDragOver={(e) => e.preventDefault()}
+      onDragOver={onDragOver}
       onDrop={onDrop}
       isDragging={isDragging}
     >

--- a/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
+++ b/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
@@ -22,7 +22,7 @@ const NoticeUploader = ({ isOpen }: Props) => {
     if (isOpen && uploadedFile) {
       setUploadedFile(null);
     }
-  }, [isOpen, uploadedFile, setUploadedFile]);
+  }, [isOpen, setUploadedFile]);
 
   const handleUploadCancelButtonClick = () => {
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
+++ b/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
@@ -36,12 +36,17 @@ const NoticeUploader = ({ isOpen }: Props) => {
 
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsDragging(false);
 
     const droppedFile = e.dataTransfer.files[0];
 
     if (!droppedFile) return;
     validateAndSetFile(droppedFile);
+  };
+
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
   };
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -63,7 +68,7 @@ const NoticeUploader = ({ isOpen }: Props) => {
     <StyledNoticeUploader
       onDragEnter={(e) => handleDragState(e, true)}
       onDragLeave={(e) => handleDragState(e, false)}
-      onDragOver={(e) => e.preventDefault()}
+      onDragOver={onDragOver}
       onDrop={onDrop}
       isDragging={isDragging}
     >


### PR DESCRIPTION
## 📄 Summary

> 어드민의 파일이 업로드가 안되는 문제를 해결했습니다. 
> 원인은 파일 업로드 모달을 열 때, 전에 있는 파일이 있을 수도 있기에 uploadFile을 null 바꾸는 로직이 있습니다. 하지만 해당 로직(useEffect)의 의존성 배열에 uploadFile이 있어 파일이 들어갈 때도 작동하여 파일이 업로드가 안되는 '것'처럼 보였습니다.

<br>

## 🔨 Tasks

- 잘못된 의존성 배열 수정
- 부모 컴포넌트에 대한 방어적 코드 추가
- 인라인 이벤트 핸들러를 따로 빼서 처리

<br>

## 🙋🏻 More
