### PR TITLE
fix(user): 증명사진 업로드 시 빈 downloadUrl 처리 개선

### DIFF
--- a/apps/user/src/components/form/ProfileUploader/ProfileUploader.tsx
+++ b/apps/user/src/components/form/ProfileUploader/ProfileUploader.tsx
@@ -188,7 +188,7 @@ const ProfileUploader = () => {
       </Text>
       {previewUrl ? (
         <ImagePreview src={previewUrl} alt="preview-image" />
-      ) : profileUrl ? (
+      ) : profileUrl?.downloadUrl ? (
         <ImagePreview src={profileUrl.downloadUrl} alt="profile-image" />
       ) : (
         <UploadImageBox
@@ -208,7 +208,7 @@ const ProfileUploader = () => {
           </Column>
         </UploadImageBox>
       )}
-      {(previewUrl || profileUrl) && (
+      {(previewUrl || profileUrl?.downloadUrl) && (
         <Button size="SMALL" onClick={openFileUploader}>
           재업로드
         </Button>


### PR DESCRIPTION
## 📄 Summary

>증명사진 업로드 시 빈 downloadUrl로 인한 오류를 방지하기 위해  ProfileUploader 컴포넌트의 조건 검사를 개선했습니다. profileUrl만 체크하던 것을 profileUrl?.downloadUrl로 변경하여 downloadUrl이 실제로 존재할 때만 이미지를 표시하도록 수정했습니다.


<br>

## 🔨 Tasks

- ProfileUploader 컴포넌트 profileUrl 조건 검사 개선

<br>

## 🙋🏻 More
