### PR TITLE
fix(admin): 출신학교 현황 표 디자인과 맞춤

### DIFF
--- a/apps/admin/src/components/analysis/ApplicationTypeRatio/DetailTable/DetailTable.tsx
+++ b/apps/admin/src/components/analysis/ApplicationTypeRatio/DetailTable/DetailTable.tsx
@@ -18,11 +18,11 @@ const DetailTable = ({ formList }: DetailTableProps) => {
           <Column gap={40}>
             <Column>
               <Text fontType="btn2">일반 전형 지원 비율</Text>
-              <Text fontType="D2">{regularRatio} %</Text>
+              <Text fontType="D2">{regularRatio}</Text>
             </Column>
             <Column>
               <Text fontType="btn2">특별 전형 지원 비율</Text>
-              <Text fontType="D2">{specialAdmissionRatio} %</Text>
+              <Text fontType="D2">{specialAdmissionRatio}</Text>
             </Column>
           </Column>
         </Column>

--- a/apps/admin/src/components/analysis/GenderRatio/GenderRatioDetailTable/GenderRatioDetailTable.tsx
+++ b/apps/admin/src/components/analysis/GenderRatio/GenderRatioDetailTable/GenderRatioDetailTable.tsx
@@ -31,11 +31,11 @@ const GenderRatioDetailTable: React.FC<GenderRatioDetailTableProps> = ({
           <Column gap={40}>
             <Column>
               <Text fontType="H4">전체 남학생 지원 인원</Text>
-              <Text fontType="D2">{totalCounts?.maleCount} 점</Text>
+              <Text fontType="D2">{totalCounts?.maleCount} 명</Text>
             </Column>
             <Column>
               <Text fontType="H4">전체 여학생 지원 인원</Text>
-              <Text fontType="D2">{totalCounts?.femaleCount} 점</Text>
+              <Text fontType="D2">{totalCounts?.femaleCount} 명</Text>
             </Column>
           </Column>
         </Column>

--- a/apps/admin/src/components/analysis/GraduatedSchool/GraduatedAreaTable/GraduatedAreaTableHeader/GraduatedAreaTableHeader.tsx
+++ b/apps/admin/src/components/analysis/GraduatedSchool/GraduatedAreaTable/GraduatedAreaTableHeader/GraduatedAreaTableHeader.tsx
@@ -4,18 +4,20 @@ import { Row, Text } from '@maru/ui';
 const GraduatedAreaTableHeader = () => {
   return (
     <TableHeader>
-      <Row gap={48}>
-        <Text fontType="p2" width={50}>
-          번호
-        </Text>
-        <Text fontType="p2" width={540}>
-          이름
-        </Text>
-      </Row>
-      <Row gap={100}>
-        <Text fontType="p2" width={50}>
-          출신 학교
-        </Text>
+      <Row gap={120}>
+        <Row gap={480}>
+          <Row gap={48}>
+            <Text fontType="p2" width={50}>
+              번호
+            </Text>
+            <Text fontType="p2" width={1}>
+              이름
+            </Text>
+          </Row>
+          <Text fontType="p2" width={50}>
+            출신 학교
+          </Text>
+        </Row>
         <Text fontType="p2">학교 위치</Text>
       </Row>
     </TableHeader>

--- a/apps/admin/src/components/analysis/GraduatedSchool/GraduatedAreaTable/GraduatedAreaTableItem/GraduatedAreaTableItem.tsx
+++ b/apps/admin/src/components/analysis/GraduatedSchool/GraduatedAreaTable/GraduatedAreaTableItem/GraduatedAreaTableItem.tsx
@@ -16,18 +16,20 @@ const GraduatedAreaTableItem = ({
 }: NoticeTableItemProps) => {
   return (
     <TableItem key={id}>
-      <Row gap={48}>
-        <Text fontType="p2" width={50}>
-          {id}
-        </Text>
-        <Text fontType="p2" width={1}>
-          {applicantName}
-        </Text>
-      </Row>
-      <Row gap={140}>
-        <Text fontType="p2" width={50}>
-          {schoolName}
-        </Text>
+      <Row gap={120}>
+        <Row gap={480}>
+          <Row gap={48}>
+            <Text fontType="p2" width={50}>
+              {id}
+            </Text>
+            <Text fontType="p2" width={1}>
+              {applicantName}
+            </Text>
+          </Row>
+          <Text fontType="p2" width={50}>
+            {schoolName}
+          </Text>
+        </Row>
         <Text fontType="p2">{schoolAddress}</Text>
       </Row>
     </TableItem>


### PR DESCRIPTION
## 📄 Summary

> 분석페이지와 디자인이 다른 부분을 수정했습니다.

<br>

## 🔨 Tasks

- 디자인과 다른 단위 변경
- 출신학교 표 디자인과 같게 하기

<br>

## 🙋🏻 More
<img width="1398" height="803" alt="스크린샷 2025-08-21 오전 4 19 58" src="https://github.com/user-attachments/assets/a18bfcfa-fd1c-4e65-b200-a017be1c10f5" />
<img width="1242" height="865" alt="스크린샷 2025-08-21 오전 4 20 05" src="https://github.com/user-attachments/assets/e931967f-db08-4437-8f6e-11263ca41e2e" />
<img width="1488" height="579" alt="스크린샷 2025-08-21 오전 4 20 11" src="https://github.com/user-attachments/assets/c9b49f3d-0253-4fe9-a35f-c45d119bf985" />
