### PR TITLE
style(admin): 자주묻는질문 페이지에서 텍스트 길이가 길어질경우 페이지가 화면을 초과하는 오류

### DIFF
--- a/apps/admin/src/components/faq/FaqDetail/FaqDetail.tsx
+++ b/apps/admin/src/components/faq/FaqDetail/FaqDetail.tsx
@@ -1,5 +1,5 @@
 import { ROUTES } from '@/constants/common/constant';
-import { color, font } from '@maru/design-system';
+import { color } from '@maru/design-system';
 import { Button, Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { useRouter } from 'next/navigation';
@@ -26,7 +26,7 @@ const FaqDetail = ({ id }: FaqDetailProps) => {
     <StyledFaqDetail>
       <FaqDetailHeader>
         <Column gap={20}>
-          <Text fontType="H1" color={color.gray900} whiteSpace='break-spaces'>
+          <Text fontType="H1" color={color.gray900} whiteSpace="break-spaces">
             {faqDetailData.title}
           </Text>
           <Row gap={16} alignItems="center">
@@ -57,7 +57,9 @@ const FaqDetail = ({ id }: FaqDetailProps) => {
           </Button>
         </Row>
       </FaqDetailHeader>
-      <Text fontType='p2' color={color.gray900} whiteSpace='break-spaces'>{faqDetailData.content}</Text>
+      <Text fontType="p2" color={color.gray900} whiteSpace="break-spaces">
+        {faqDetailData.content}
+      </Text>
     </StyledFaqDetail>
   ) : null;
 };

--- a/apps/admin/src/components/faq/FaqDetail/FaqDetail.tsx
+++ b/apps/admin/src/components/faq/FaqDetail/FaqDetail.tsx
@@ -26,7 +26,7 @@ const FaqDetail = ({ id }: FaqDetailProps) => {
     <StyledFaqDetail>
       <FaqDetailHeader>
         <Column gap={20}>
-          <Text fontType="H1" color={color.gray900}>
+          <Text fontType="H1" color={color.gray900} whiteSpace='break-spaces'>
             {faqDetailData.title}
           </Text>
           <Row gap={16} alignItems="center">
@@ -57,7 +57,7 @@ const FaqDetail = ({ id }: FaqDetailProps) => {
           </Button>
         </Row>
       </FaqDetailHeader>
-      <Content>{faqDetailData.content}</Content>
+      <Text fontType='p2' color={color.gray900} whiteSpace='break-spaces'>{faqDetailData.content}</Text>
     </StyledFaqDetail>
   ) : null;
 };
@@ -76,9 +76,4 @@ const FaqDetailHeader = styled.div`
   gap: 16px;
   border-bottom: 1px solid ${color.gray300};
   padding-bottom: 16px;
-`;
-
-const Content = styled.div`
-  ${font.p2};
-  color: ${color.gray900};
 `;

--- a/apps/admin/src/layouts/AppLayout.tsx
+++ b/apps/admin/src/layouts/AppLayout.tsx
@@ -28,6 +28,6 @@ const StyledAppLayout = styled.div`
 
 const Section = styled.section`
   flex: 1;
-  min-width: fit-content;
+  min-width: auto;
   overflow: auto;
 `;


### PR DESCRIPTION
## 📄 Summary

> 자주묻는질문 페이지에서 제목이나 본문의 텍스트의 길이가 과하게 길어질경우 페이지가 가로로 길어지게 되는 오류를 해결했습니다.

<br>

## 🔨 Tasks

- AppLayout Section min-width 변경
- Text wrap 설정

<br>

## 🙋🏻 More
