### PR TITLE
style(admin): 어드민 공지 페이지 제목 길이 문제 해결

### DIFF
--- a/apps/admin/src/components/notice/NoticeDetail/NoticeDetail.tsx
+++ b/apps/admin/src/components/notice/NoticeDetail/NoticeDetail.tsx
@@ -26,7 +26,7 @@ const NoticeDetail = ({ id }: NoticeDetailProps) => {
     <StyledNoticeDetail>
       <NoticeDetailHeader>
         <Column gap={20}>
-          <Text fontType="H1" color={color.gray900}>
+          <Text fontType="H1" color={color.gray900} whiteSpace="break-spaces">
             {noticeDetailData.title}
           </Text>
           <Text fontType="p2" color={color.gray600}>

--- a/apps/admin/src/components/notice/NoticeTable/NoticeTableItem/NoticeTableItem.tsx
+++ b/apps/admin/src/components/notice/NoticeTable/NoticeTableItem/NoticeTableItem.tsx
@@ -24,7 +24,7 @@ const NoticeTableItem = ({ id, title, updatedAt }: NoticeTableItemProps) => {
           <Text fontType="p2" width={50}>
             {id}
           </Text>
-          <Text fontType="p2" width={540}>
+          <Text fontType="p2" width={540} ellipsis>
             {title}
           </Text>
         </Row>


### PR DESCRIPTION
## 📄 Summary

> 어드민 공지 페이지의 제목 길이가 길어질 때 생기는 문제들을 해결했습니다

<br>

## 🔨 Tasks

- 상세 페이지 타이틀 줄내림 적용
- 전체보기 페이지 타이틀 말줄임표 적용

<br>

## 🙋🏻 More
