### PR TITLE
fix(user): form 가산점 스텝의 UnderlineButton이 '봉사 시간'으로 표시됨

### DIFF
--- a/apps/user/src/app/form/Grade/Certificate/Certificate.tsx
+++ b/apps/user/src/app/form/Grade/Certificate/Certificate.tsx
@@ -10,7 +10,7 @@ const Certificate = () => {
     <>
       <Column gap={24}>
         <NavigationBar>
-          <UnderlineButton active={true}>봉사시간</UnderlineButton>
+          <UnderlineButton active={true}>자격증</UnderlineButton>
         </NavigationBar>
         <CertificateCalculator />
       </Column>


### PR DESCRIPTION
## 📄 Summary

> UnderlineButton의 텍스트를 수정했습니다. `봉사시간` -> `자격증`

<br>

## 🔨 Tasks

<img width="753" height="486" alt="스크린샷 2025-10-14 오후 5 41 04" src="https://github.com/user-attachments/assets/4ff27fd0-4c41-4e03-a9fd-1fc5fa258cbd" />


<br>

## 🙋🏻 More
