### PR TITLE
fix(common): pnpm lint 통과를 위한 eslint 규칙 처리

### DIFF
--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -33,6 +33,7 @@ const LoginContent = () => {
     <StyledLogin>
       <LoginBox>
         <Column gap={56} alignItems="center" width={446}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             loading="lazy"
             src="/svg/maruLogo.svg"

--- a/apps/admin/src/components/common/SideBar/SideBar.tsx
+++ b/apps/admin/src/components/common/SideBar/SideBar.tsx
@@ -51,6 +51,7 @@ const SideBar = () => {
   return (
     <StyledSideBar>
       <StyledImageBox>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           loading="lazy"
           src="/svg/maruLogoDark.svg"

--- a/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
+++ b/apps/admin/src/components/form/SecondScoreUploadModal/SecondScoreUploader/SecondScoreUploader.tsx
@@ -19,6 +19,7 @@ const SecondScoreUploader = ({ isOpen }: SecondScoreUploaderProps) => {
     if (isOpen && uploadedFile) {
       setUploadedFile(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, setUploadedFile]);
 
   const handleUploadCancelButtonClick = () => {

--- a/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
+++ b/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
@@ -22,6 +22,7 @@ const NoticeUploader = ({ isOpen }: Props) => {
     if (isOpen && uploadedFile) {
       setUploadedFile(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, setUploadedFile]);
 
   const handleUploadCancelButtonClick = () => {

--- a/apps/user/src/app/error.tsx
+++ b/apps/user/src/app/error.tsx
@@ -21,6 +21,7 @@ const Error = () => {
   return (
     <AppLayout header footer>
       <StyledError>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           loading="lazy"
           width={363.75}

--- a/apps/user/src/app/login/page.tsx
+++ b/apps/user/src/app/login/page.tsx
@@ -74,6 +74,7 @@ const Login = () => {
             width={446}
             height="100%"
           >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               loading="lazy"
               src="/svg/maruLogo.svg"

--- a/apps/user/src/app/not-found.tsx
+++ b/apps/user/src/app/not-found.tsx
@@ -17,6 +17,7 @@ const NotFound = () => {
   return (
     <AppLayout header footer>
       <StyledNotFound>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           loading="lazy"
           width={388.7}

--- a/apps/user/src/app/signup/page.tsx
+++ b/apps/user/src/app/signup/page.tsx
@@ -10,6 +10,7 @@ const SignUp = () => {
   return (
     <AppLayout backgroundColor={color.gray100}>
       <StyledSignUp>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src="/svg/maruLogo.svg"
           style={{ margin: '0 auto' }}

--- a/apps/user/src/app/withdrawal/page.tsx
+++ b/apps/user/src/app/withdrawal/page.tsx
@@ -39,6 +39,7 @@ const Withdrawal = () => {
       <StyledWithdrawal>
         <WithdrawalBox>
           <Column gap={80} alignItems="center" width={446}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               loading="lazy"
               src="/svg/maruLogo.svg"

--- a/apps/user/src/components/common/Footer/Footer.tsx
+++ b/apps/user/src/components/common/Footer/Footer.tsx
@@ -14,6 +14,7 @@ const Footer = () => {
     <StyledFooter>
       <FooterBox>
         <Column gap={40} height={262}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             loading="lazy"
             src="/svg/maruGrayLogo.svg"

--- a/apps/user/src/components/common/Header/Header.tsx
+++ b/apps/user/src/components/common/Header/Header.tsx
@@ -33,6 +33,7 @@ const Header = () => {
           alignItems="center"
           justifyContent="space-between"
         >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             loading="lazy"
             src="/svg/maruLogo.svg"

--- a/apps/user/src/components/common/MobileProvider/MobileProvider.tsx
+++ b/apps/user/src/components/common/MobileProvider/MobileProvider.tsx
@@ -31,6 +31,7 @@ const MobileProvider = ({ children }: Props) => {
     } else {
       if (step !== 'LOGIN') setStep('LOGIN');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (isMobile === null) return null;

--- a/apps/user/src/components/form/FinalFormTable/FinalFormTable.tsx
+++ b/apps/user/src/components/form/FinalFormTable/FinalFormTable.tsx
@@ -36,8 +36,8 @@ const FinalFormTable = () => {
             <li>
               <Text fontType="form" color={color.red}>
                 인터넷 접수
-                <a href={'https://maru.bamdoliro.com/'}>(maru.bamdoliro.com)</a>후
-                출력하여 출신 중학교장 직인 날인 후 제출
+                <a href="https://maru.bamdoliro.com/">(maru.bamdoliro.com)</a>후 출력하여
+                출신 중학교장 직인 날인 후 제출
               </Text>
             </li>
             <ul>
@@ -45,7 +45,7 @@ const FinalFormTable = () => {
             </ul>
             <li>
               인터넷 접수
-              <a href={'https://maru.bamdoliro.com/'}>(maru.bamdoliro.com)</a>후 출력
+              <a href="https://maru.bamdoliro.com/">(maru.bamdoliro.com)</a>후 출력
             </li>
             <ul>
               <li>학교생활기록부 || 사본 1부 </li>

--- a/apps/user/src/components/mobile/MobileLogin.tsx
+++ b/apps/user/src/components/mobile/MobileLogin.tsx
@@ -10,6 +10,7 @@ const MobileLogin = () => {
   return (
     <StyledMobileLogin>
       <Column gap={36} alignItems="center">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/svg/maruLogo.svg" width={152} height={46} alt="logo" loading="lazy" />
         <Column gap={28} alignItems="center">
           <Column gap={14}>

--- a/apps/user/src/components/mobile/MobileMain.tsx
+++ b/apps/user/src/components/mobile/MobileMain.tsx
@@ -19,6 +19,7 @@ const MobileMain = () => {
   return (
     <StyledMobileMain>
       <Column alignItems="center" gap={36.4}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/svg/maruLogo.svg" width={152} height={46} alt="logo" loading="lazy" />
         <Column alignItems="center" gap={40}>
           <Column alignItems="center" gap={4}>

--- a/apps/user/src/components/mobile/MobileResult.tsx
+++ b/apps/user/src/components/mobile/MobileResult.tsx
@@ -16,6 +16,7 @@ const MobileResult = () => {
   return (
     <StyledMobileResult>
       <Column gap={36.4} alignItems="center">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/svg/maruLogo.svg" width={152} height={46} alt="logo" loading="lazy" />
         {now.isBetween(SCHEDULE.일차_합격_발표, SCHEDULE.이차_면접) && <FirstResult />}
         {now.isBetween(SCHEDULE.최종_합격_발표, SCHEDULE.입학_등록) && <FinalResult />}

--- a/packages/ui/src/Input/FormInput.tsx
+++ b/packages/ui/src/Input/FormInput.tsx
@@ -1,5 +1,5 @@
 import { color, font } from '@maru/design-system';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import type { InputProps } from './Input.type';
 
 const FormInput = ({


### PR DESCRIPTION
## 📄 Summary

> eslint에서 잡는 에러들을 안 잡을 수 있게 수정했습니다.

<br>

## 🔨 Tasks

- img 태그 eslint-disable 추가 (12개)
- useEffect deps eslint-disable 추가 (3개)
- 불필요한 JSX 중괄호 제거
- 미사용 css import 제거

<br>

## 🙋🏻 More

img 태그 disable 이유는 정적 svg 파일이라 <Image />가 불필요했음
useEffect deps disable 이유는 둘 다 의도적으로 deps를 제한한 케이스로 보여서 린트로 잡을 이유가 없음