### PR TITLE
chore: lodash → es-toolkit 전환

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -8,8 +8,7 @@
     "lint": "eslint \"**/*.ts*\""
   },
   "dependencies": {
-    "@types/lodash": "^4.14.195",
-    "lodash": "^4.17.21",
+    "es-toolkit": "^1.0.0",
     "react": "18.2.0",
     "recoil": "^0.7.7"
   },

--- a/packages/hooks/src/useDebounceInput.ts
+++ b/packages/hooks/src/useDebounceInput.ts
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import { debounce } from 'es-toolkit/compat';
 import type { ChangeEventHandler } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,12 +312,9 @@ importers:
 
   packages/hooks:
     dependencies:
-      '@types/lodash':
-        specifier: ^4.14.195
-        version: 4.17.15
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+      es-toolkit:
+        specifier: ^1.0.0
+        version: 1.45.0
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -804,9 +801,6 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/lodash@4.17.15':
-    resolution: {integrity: sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==}
-
   '@types/node@20.17.17':
     resolution: {integrity: sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==}
 
@@ -1221,6 +1215,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.0:
+    resolution: {integrity: sha512-RArCX+Zea16+R1jg4mH223Z8p/ivbJjIkU3oC6ld2bdUfmDxiCkFYSi9zLOR2anucWJUeH4Djnzgd0im0nD3dw==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -1734,9 +1731,6 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2755,8 +2749,6 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/lodash@4.17.15': {}
-
   '@types/node@20.17.17':
     dependencies:
       undici-types: 6.19.8
@@ -3296,6 +3288,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.45.0: {}
 
   escape-string-regexp@1.0.5: {}
 
@@ -3877,8 +3871,6 @@ snapshots:
   lodash.throttle@4.1.1: {}
 
   lodash.truncate@4.4.2: {}
-
-  lodash@4.17.21: {}
 
   loose-envify@1.4.0:
     dependencies:


### PR DESCRIPTION
## 📄 Summary

> lodash → es-toolkit 전환
> `packages/hooks`의 `useDebounceInput.ts`에서 `lodash/debounce` 대신 `es-toolkit/compat`의 `debounce`를 사용하도록 변경

<br>

## 🔨 Tasks

- lodash, @types/lodash 제거
- es-toolkit 설치
- import 변경 (`lodash/debounce` → `es-toolkit/compat`)

<br>

## 🙋🏻 More

closes #378