### PR TITLE
chore: 모노레포 패키지 버전 통일

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -40,6 +40,6 @@
     "@types/node": "^20",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
-    "typescript": "^5.1.3"
+    "typescript": "5.5.4"
   }
 }

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -42,6 +42,6 @@
     "@types/node": "^20.17.17",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
-    "typescript": "^5.1.3"
+    "typescript": "5.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint": "^7.32.0",
     "prettier": "^2.8.8",
     "turbo": "^2.3.3",
-    "typescript": "^5.1.3"
+    "typescript": "5.5.4"
   },
   "packageManager": "pnpm@9.0.0"
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -16,7 +16,7 @@
     "@maru/eslint-config": "workspace:*",
     "@maru/eslint-config-ts": "workspace:*",
     "@maru/tsconfig": "workspace:*",
-    "@types/react": "18.2.13",
-        "typescript": "^5.1.3"
+    "@types/react": "18.3.1",
+        "typescript": "5.5.4"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint \"**/*.ts*\""
   },
   "dependencies": {
-    "@emotion/react": "^11.11.0",
-    "@emotion/styled": "^11.11.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "recoil": "^0.7.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^2.3.3
         version: 2.4.0
       typescript:
-        specifier: ^5.1.3
+        specifier: 5.5.4
         version: 5.5.4
 
   apps/admin:
@@ -106,7 +106,7 @@ importers:
         specifier: 18.3.0
         version: 18.3.0
       typescript:
-        specifier: ^5.1.3
+        specifier: 5.5.4
         version: 5.5.4
 
   apps/user:
@@ -200,7 +200,7 @@ importers:
         specifier: 18.3.0
         version: 18.3.0
       typescript:
-        specifier: ^5.1.3
+        specifier: 5.5.4
         version: 5.5.4
 
   configs/eslint-config:
@@ -283,10 +283,10 @@ importers:
     dependencies:
       '@emotion/react':
         specifier: ^11.14.0
-        version: 11.14.0(@types/react@18.2.13)(react@18.2.0)
+        version: 11.14.0(@types/react@18.3.1)(react@18.2.0)
       '@emotion/styled':
         specifier: ^11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.2.13)(react@18.2.0))(@types/react@18.2.13)(react@18.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.2.0))(@types/react@18.3.1)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -304,10 +304,10 @@ importers:
         specifier: workspace:*
         version: link:../../configs/tsconfig
       '@types/react':
-        specifier: 18.2.13
-        version: 18.2.13
+        specifier: 18.3.1
+        version: 18.3.1
       typescript:
-        specifier: ^5.1.3
+        specifier: 5.5.4
         version: 5.5.4
 
   packages/hooks:
@@ -415,10 +415,10 @@ importers:
   packages/utils:
     dependencies:
       '@emotion/react':
-        specifier: ^11.11.0
+        specifier: ^11.14.0
         version: 11.14.0(@types/react@18.3.1)(react@18.2.0)
       '@emotion/styled':
-        specifier: ^11.11.0
+        specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.2.0))(@types/react@18.3.1)(react@18.2.0)
       react:
         specifier: ^18.2.0
@@ -2449,22 +2449,6 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@18.2.13)(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.26.9
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.2.0)
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.13
-    transitivePeerDependencies:
-      - supports-color
-
   '@emotion/react@11.14.0(@types/react@18.3.1)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.9
@@ -2490,21 +2474,6 @@ snapshots:
       csstype: 3.1.3
 
   '@emotion/sheet@1.4.0': {}
-
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.13)(react@18.2.0))(@types/react@18.2.13)(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.26.9
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@18.2.13)(react@18.2.0)
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.2.0)
-      '@emotion/utils': 1.4.2
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.13
-    transitivePeerDependencies:
-      - supports-color
 
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.2.0))(@types/react@18.3.1)(react@18.2.0)':
     dependencies:


### PR DESCRIPTION
## 📄 Summary

> 모노레포 내 `@types/react`, `typescript`, `@emotion/*` 버전이 패키지마다 달라 통일

<br>

## 🔨 Tasks

- `@types/react` → 18.3.1로 통일 (design-system)
- `typescript` → 5.5.4로 통일 (apps/*, root, design-system)
- `@emotion/*` → ^11.14.0으로 통일 (utils)

<br>

## 🙋🏻 More

closes #376