### PR TITLE
chore: CI에 lint + type-check 스텝 추가

### DIFF
--- a/.github/workflows/maru-admin.yml
+++ b/.github/workflows/maru-admin.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run Lint (admin App)
+        run: pnpm turbo run lint --filter=./apps/admin
+
+      - name: Run Type Check (admin App)
+        run: pnpm turbo run check-types --filter=./apps/admin
+
       - name: Run Build (admin App)
         run: pnpm turbo run build --filter=./apps/admin --continue

--- a/.github/workflows/maru.yml
+++ b/.github/workflows/maru.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run Lint (User App)
+        run: pnpm turbo run lint --filter=./apps/user
+
+      - name: Run Type Check (User App)
+        run: pnpm turbo run check-types --filter=./apps/user
+
       - name: Run Build (User App)
         run: pnpm turbo run build --filter=./apps/user --continue

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,9 @@
     "lint": {
       "dependsOn": ["^build"]
     },
+    "check-types": {
+      "dependsOn": ["^build"]
+    },
     "dev": {
       "dependsOn": ["^build"],
       "outputs": [".next/**"],


### PR DESCRIPTION
## 📄 Summary

> CI 워크플로우에 lint, type-check 스텝 추가 및 turbo.json에 check-types 태스크 등록

<br>

## 🔨 Tasks

- maru.yml에 lint, check-types 스텝 추가
- maru-admin.yml에도 동일 적용
- turbo.json에 check-types 태스크 등록

<br>

## 🙋🏻 More

closes #380

⚠️ #378 (lodash → es-toolkit)이 먼저 머지되어야 check-types가 통과합니다