### PR TITLE
chore(#398): 이슈 자동 어싸인 워크플로우 추가

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -43,6 +43,12 @@ jobs:
                   issue_number: issue.number,
                   assignees: [issue.user.login],
                 });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `👋 @${issue.user.login} 님이 자동으로 어싸인되었습니다.`,
+                });
                 core.info(`Assigned #${issue.number} to ${issue.user.login}`);
               } catch (err) {
                 core.warning(`Failed to assign #${issue.number}: ${err.message}`);


### PR DESCRIPTION
## Summary
- 10분 간격 cron으로 어싸인 없는 이슈를 생성자에게 자동 할당
- Bamdoliro 조직 멤버만 대상 (외부 사용자 제외)
- `workflow_dispatch`로 수동 실행도 가능

## Test plan
- [x] YAML 문법 유효
- [ ] workflow_dispatch로 수동 테스트

closes #398