### PR TITLE
fix(user): DdayBox 요일 표시 영어에서 한글로 변경

### DIFF
--- a/apps/user/src/components/main/AdmissionTimelineBox/DdayBox/DdayBox.hooks.ts
+++ b/apps/user/src/components/main/AdmissionTimelineBox/DdayBox/DdayBox.hooks.ts
@@ -9,9 +9,9 @@ import utc from 'dayjs/plugin/utc';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 
+dayjs.locale('ko');
 dayjs.extend(isBetween);
 dayjs.extend(utc);
-dayjs.locale('ko');
 
 const SCHEDULE_STATUS = new Map([
   [SCHEDULE.원서_접수.toString(), '원서 접수 시작까지'],
@@ -74,7 +74,7 @@ export const useRemainDate = () => {
 
   const isInEnrollmentPeriod = now.isBetween(SCHEDULE.입학_등록, SCHEDULE.입학_등록_마감);
   const displayDate = isInEnrollmentPeriod ? SCHEDULE.입학_등록_마감 : currentTime;
-  const targetDate = displayDate.format('YYYY년 MM월 DD일 (ddd) HH:mm');
+  const targetDate = displayDate.locale('ko').format('YYYY년 MM월 DD일 (ddd) HH:mm');
 
   const isSecondRoundDay = now.isBetween(SCHEDULE.이차_면접, SCHEDULE.이차_면접_종료);
   const isAfterFormPeriod = dayjs().isBetween(


### PR DESCRIPTION
## 📄 Summary

> DdayBox의 요일이 영어 약자로 뜨는 문제를 해결합니다.

<br>

## 🔨 Tasks

- dayjs 로케일 초기화 순서 변경 (locale('ko') 를 extend 전에 호출
- targetDate 포맷에 명시적 로케일 적용 .locale('ko') 추가
- 요일이 한글(월, 화, 수...)로 정상 표시되도록 수정

<br>

## 🙋🏻 More
