### PR TITLE
refactor(common): useToast 폴링 제거 및 progress CSS 전환

### DIFF
--- a/apps/admin/src/components/Provider.tsx
+++ b/apps/admin/src/components/Provider.tsx
@@ -3,12 +3,11 @@
 import { GlobalStyle } from '@maru/design-system';
 import { OverlayProvider } from '@toss/use-overlay';
 import type { ReactNode } from 'react';
-import 'react-toastify/dist/ReactToastify.css';
 import { RecoilRoot } from 'recoil';
 import { Toast } from '@maru/ui';
 import styled from '@emotion/styled';
 import useToast from '@maru/hooks/src/useToast';
-import type { ToastProgress } from '@maru/hooks/src/useToast';
+import type { ToastItem } from '@maru/hooks/src/useToast';
 
 interface Props {
   children: ReactNode;
@@ -19,12 +18,12 @@ const GlobalToast = () => {
 
   return (
     <StyledToastContainer>
-      {toasts.map((toast: ToastProgress) => (
+      {toasts.map((toast: ToastItem) => (
         <StyledToastWrapper key={toast.id}>
           <Toast
             type={toast.toastType}
             device={toast.device}
-            progress={toast.progress}
+            duration={toast.duration}
             onClose={() => removeToast(toast.id)}
           >
             {toast.message}

--- a/apps/user/src/components/Provider.tsx
+++ b/apps/user/src/components/Provider.tsx
@@ -24,7 +24,7 @@ const GlobalToast = () => {
           <Toast
             type={toast.toastType}
             device={toast.device}
-            progress={toast.progress}
+            duration={toast.duration}
             onClose={() => removeToast(toast.id)}
           >
             {toast.message}

--- a/packages/hooks/src/useToast.ts
+++ b/packages/hooks/src/useToast.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef } from 'react';
 import { atom, useRecoilState } from 'recoil';
 
 export type ToastType = 'ERROR' | 'SUCCESS';
@@ -10,12 +10,6 @@ export type ToastItem = {
   toastType: ToastType;
   device: DeviceType;
   duration: number;
-  createdAt: number;
-};
-
-export type ToastProgress = ToastItem & {
-  progress: number;
-  remaining: number;
 };
 
 const toastListState = atom<ToastItem[]>({
@@ -26,19 +20,6 @@ const toastListState = atom<ToastItem[]>({
 const useToast = () => {
   const [toasts, setToasts] = useRecoilState(toastListState);
   const timeoutRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-  const [tick, setTick] = useState(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    intervalRef.current = setInterval(() => setTick((t) => t + 1), 100);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      Object.keys(timeoutRefs.current).forEach((key) => {
-        clearTimeout(timeoutRefs.current[key]);
-      });
-      timeoutRefs.current = {};
-    };
-  }, []);
 
   const removeToast = useCallback(
     (id: string) => {
@@ -67,18 +48,11 @@ const useToast = () => {
       duration = 3000,
     ) => {
       const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-      const createdAt = Date.now();
-      const item: ToastItem = {
-        id,
-        message,
-        toastType: type,
-        device,
-        duration,
-        createdAt,
-      };
+      const item: ToastItem = { id, message, toastType: type, device, duration };
       setToasts((prev) => [...prev, item]);
+
       timeoutRefs.current[id] = setTimeout(() => {
-        setToasts((prev) => prev.filter((p) => p.id !== id));
+        setToasts((prev) => prev.filter((t) => t.id !== id));
         delete timeoutRefs.current[id];
       }, duration);
 
@@ -87,34 +61,8 @@ const useToast = () => {
     [setToasts],
   );
 
-  const toastsWithProgress: ToastProgress[] = toasts.map((t) => {
-    const elapsed = Date.now() - t.createdAt;
-    const progress = Math.min(1, elapsed / t.duration);
-    const remaining = Math.max(0, t.duration - elapsed);
-    return { ...t, progress, remaining };
-  });
-
-  useEffect(() => {
-    const now = Date.now();
-    const expiredIds = toasts
-      .filter((t) => now - t.createdAt >= t.duration)
-      .map((t) => t.id);
-
-    if (expiredIds.length > 0) {
-      setToasts((prev) => prev.filter((t) => expiredIds.indexOf(t.id) === -1));
-      expiredIds.forEach((id) => {
-        if (timeoutRefs.current[id]) {
-          clearTimeout(timeoutRefs.current[id]);
-          delete timeoutRefs.current[id];
-        }
-      });
-    }
-  }, [tick, toasts, setToasts]);
-
-  void tick;
-
   return {
-    toasts: toastsWithProgress,
+    toasts,
     toast,
     removeToast,
     clearToasts,

--- a/packages/ui/src/Toast/Toast.tsx
+++ b/packages/ui/src/Toast/Toast.tsx
@@ -11,7 +11,7 @@ interface ToastProps {
   width?: CSSProperties['width'];
   type: 'ERROR' | 'SUCCESS';
   device?: 'MOBILE' | 'COMPUTER';
-  progress?: number;
+  duration?: number;
   onClose?: () => void;
 }
 
@@ -20,7 +20,7 @@ const Toast = ({
   width,
   type,
   device = 'COMPUTER',
-  progress = 0,
+  duration = 3000,
 }: ToastProps) => {
   return (
     <StyledToast style={{ width }} device={device}>
@@ -35,7 +35,7 @@ const Toast = ({
         </Text>
       </StyledToastContent>
       <StyledProgressBar>
-        <StyledProgressFill progress={progress} type={type} />
+        <StyledProgressFill duration={duration} type={type} />
       </StyledProgressBar>
     </StyledToast>
   );
@@ -90,9 +90,18 @@ const StyledProgressBar = styled.div`
   overflow: hidden;
 `;
 
-const StyledProgressFill = styled.div<{ progress: number; type: 'ERROR' | 'SUCCESS' }>`
+const StyledProgressFill = styled.div<{ duration: number; type: 'ERROR' | 'SUCCESS' }>`
   height: 100%;
-  width: ${({ progress }) => `${progress * 100}%`};
+  width: 100%;
   background-color: ${({ type }) => (type === 'ERROR' ? color.red : color.maruDefault)};
-  transition: width 0.1s linear;
+  animation: progressFill ${({ duration }) => duration}ms linear forwards;
+
+  @keyframes progressFill {
+    from {
+      width: 0%;
+    }
+    to {
+      width: 100%;
+    }
+  }
 `;


### PR DESCRIPTION
## 📄 Summary

> useToast의 100ms 무한 폴링을 제거하고, progress bar를 CSS 애니메이션으로 전환합니다.

<br>

## 🔨 Tasks

- 100ms setInterval 폴링 및 tick state 제거
- 이중 만료 처리(setTimeout + tick useEffect) → setTimeout 단일 방식으로 통합
- progress bar를 JS 계산(Date.now())에서 CSS @keyframes로 전환
- admin Provider의 미사용 react-toastify CSS import 제거

<br>

## 🙋🏻 More

closes #419