### PR TITLE
feat(common): useAuthState 컨텍스트 훅 추가

### DIFF
--- a/apps/admin/src/apis/instance/instance.ts
+++ b/apps/admin/src/apis/instance/instance.ts
@@ -20,38 +20,55 @@ export const maru = axios.create({
   },
 });
 
+interface FailedRequest {
+  resolve: () => void;
+  reject: (error?: unknown) => void;
+}
+
 let isRefreshing = false;
-let refreshPromise: Promise<void> | null = null;
+let failedQueue: FailedRequest[] = [];
+
+const processQueue = (error: unknown) => {
+  failedQueue.forEach((request) => {
+    if (error) {
+      request.reject(error);
+    } else {
+      request.resolve();
+    }
+  });
+
+  failedQueue = [];
+};
 
 const handleRefreshAndRetry = async (error: AxiosError, instance: typeof maru) => {
   const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 
-  const isTokenExpired =
-    error.response?.status === 401 &&
-    !originalRequest._retry &&
-    localStorage.getItem('isLoggedIn');
+  const isTokenExpired = error.response?.status === 401 && !originalRequest._retry;
 
   if (isTokenExpired) {
-    if (!isRefreshing) {
-      isRefreshing = true;
-
-      refreshPromise = maru
-        .patch('/auth')
-        .then(() => {})
-        .catch((refreshError) => {
-          localStorage.removeItem('isLoggedIn');
-          window.location.href = ROUTES.MAIN;
-          return Promise.reject(refreshError);
-        })
-        .finally(() => {
-          isRefreshing = false;
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        failedQueue.push({
+          resolve: () => resolve(instance(originalRequest)),
+          reject,
         });
+      });
     }
 
     originalRequest._retry = true;
+    isRefreshing = true;
 
-    await refreshPromise;
-    return instance(originalRequest);
+    try {
+      await maru.patch('/auth');
+      processQueue(null);
+      return instance(originalRequest);
+    } catch (refreshError) {
+      processQueue(refreshError);
+      window.location.href = ROUTES.MAIN;
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
   }
 
   return Promise.reject(error);

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import Provider from '@/components/Provider';
 import QueryClientProvider from '@/services/QueryClientProvider';
+import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 import StyledComponentsRegistry from '@/lib/StyledComponentRegistry';
 
@@ -14,12 +15,16 @@ interface RootLayoutProps {
 }
 
 const RootLayout = ({ children }: RootLayoutProps) => {
+  const cookieStore = cookies();
+  const initialLoggedIn =
+    cookieStore.has('accessToken') || cookieStore.has('refreshToken');
+
   return (
     <html lang="en">
       <body>
         <StyledComponentsRegistry>
           <QueryClientProvider>
-            <Provider>{children}</Provider>
+            <Provider initialLoggedIn={initialLoggedIn}>{children}</Provider>
           </QueryClientProvider>
         </StyledComponentsRegistry>
       </body>

--- a/apps/admin/src/components/Provider.tsx
+++ b/apps/admin/src/components/Provider.tsx
@@ -6,11 +6,11 @@ import type { ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import { Toast } from '@maru/ui';
 import styled from '@emotion/styled';
-import useToast from '@maru/hooks/src/useToast';
-import type { ToastItem } from '@maru/hooks/src/useToast';
+import { AuthStateProvider, useToast } from '@maru/hooks';
 
 interface Props {
   children: ReactNode;
+  initialLoggedIn: boolean;
 }
 
 const GlobalToast = () => {
@@ -18,7 +18,7 @@ const GlobalToast = () => {
 
   return (
     <StyledToastContainer>
-      {toasts.map((toast: ToastItem) => (
+      {toasts.map((toast) => (
         <StyledToastWrapper key={toast.id}>
           <Toast
             type={toast.toastType}
@@ -71,14 +71,16 @@ const StyledToastWrapper = styled.div`
   }
 `;
 
-const Provider = ({ children }: Props) => {
+const Provider = ({ children, initialLoggedIn }: Props) => {
   return (
     <RecoilRoot>
-      <OverlayProvider>
-        <GlobalStyle />
-        {children}
-        <GlobalToast />
-      </OverlayProvider>
+      <AuthStateProvider initialLoggedIn={initialLoggedIn}>
+        <OverlayProvider>
+          <GlobalStyle />
+          {children}
+          <GlobalToast />
+        </OverlayProvider>
+      </AuthStateProvider>
     </RecoilRoot>
   );
 };

--- a/apps/admin/src/services/admin/queries.ts
+++ b/apps/admin/src/services/admin/queries.ts
@@ -1,12 +1,15 @@
 import { KEY } from '@/constants/common/constant';
 import { useQuery } from '@tanstack/react-query';
 import { getAdmin } from './api';
+import { useAuthState } from '@maru/hooks';
 
 export const useAdminQuery = () => {
+  const { isLoggedIn } = useAuthState();
+
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.ADMIN],
     queryFn: getAdmin,
-    enabled: !!localStorage.getItem('isLoggedIn'),
+    enabled: isLoggedIn,
   });
   return { data: data?.data, ...restQuery };
 };

--- a/apps/admin/src/services/auth/mutations.ts
+++ b/apps/admin/src/services/auth/mutations.ts
@@ -3,7 +3,7 @@ import { useApiError } from '@/hooks';
 import type { PostLoginAuthReq } from '@/types/auth/remote';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useToast } from '@maru/hooks';
+import { useAuthState, useToast } from '@maru/hooks';
 import { deleteLogoutAdmin, postLoginAdmin } from './api';
 import { maru } from '@/apis/instance/instance';
 import type { GetAdminRes } from '@/types/admin/remote';
@@ -12,6 +12,7 @@ export const useLoginAdminMutation = ({ phoneNumber, password }: PostLoginAuthRe
   const router = useRouter();
   const { handleError } = useApiError();
   const { toast } = useToast();
+  const { setIsLoggedIn } = useAuthState();
 
   const { mutate: loginAdminMutate, ...restMutation } = useMutation({
     mutationFn: () => postLoginAdmin({ phoneNumber, password }),
@@ -23,7 +24,7 @@ export const useLoginAdminMutation = ({ phoneNumber, password }: PostLoginAuthRe
           router.replace(ROUTES.MAIN);
           return;
         }
-        localStorage.setItem('isLoggedIn', 'true');
+        setIsLoggedIn(true);
         router.replace(ROUTES.FORM);
       } catch {
         toast('관리자 정보 조회 실패', 'ERROR');
@@ -39,12 +40,13 @@ export const useLoginAdminMutation = ({ phoneNumber, password }: PostLoginAuthRe
 export const useLogoutAdminMutation = () => {
   const router = useRouter();
   const { toast } = useToast();
+  const { setIsLoggedIn } = useAuthState();
 
   const { mutate: logoutAdminMutate, ...restMutation } = useMutation({
     mutationFn: deleteLogoutAdmin,
     onSuccess: () => {
       toast('로그아웃 되었습니다.', 'SUCCESS');
-      localStorage.removeItem('isLoggedIn');
+      setIsLoggedIn(false);
       router.replace(ROUTES.MAIN);
     },
     onError: () => {

--- a/apps/user/src/apis/instance/instance.ts
+++ b/apps/user/src/apis/instance/instance.ts
@@ -36,10 +36,7 @@ maru.interceptors.response.use(
       _retry?: boolean;
     };
 
-    const isTokenExpired =
-      error.response?.status === 401 &&
-      !originalRequest._retry &&
-      localStorage.getItem('isLoggedIn');
+    const isTokenExpired = error.response?.status === 401 && !originalRequest._retry;
 
     if (isTokenExpired) {
       if (isRefreshing) {
@@ -60,7 +57,6 @@ maru.interceptors.response.use(
         return maru(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError);
-        localStorage.removeItem('isLoggedIn');
         window.location.href = '/login';
         return Promise.reject(refreshError);
       } finally {

--- a/apps/user/src/app/layout.tsx
+++ b/apps/user/src/app/layout.tsx
@@ -2,7 +2,7 @@ import Provider from '@/components/Provider';
 import GoogleAnalytics from '@/lib/GoogleAnalytics';
 import StyledComponentRegistry from '@/lib/registry';
 import QueryClientProvider from '@/services/QueryClientProvider';
-import React from 'react';
+import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
 export const metadata = {
@@ -15,6 +15,10 @@ interface Props {
 }
 
 const RootLayout = ({ children }: Props) => {
+  const cookieStore = cookies();
+  const initialLoggedIn =
+    cookieStore.has('accessToken') || cookieStore.has('refreshToken');
+
   return (
     <html lang="ko">
       <body>
@@ -23,7 +27,7 @@ const RootLayout = ({ children }: Props) => {
         ) : null}
         <StyledComponentRegistry>
           <QueryClientProvider>
-            <Provider>{children}</Provider>
+            <Provider initialLoggedIn={initialLoggedIn}>{children}</Provider>
           </QueryClientProvider>
         </StyledComponentRegistry>
       </body>

--- a/apps/user/src/app/login/page.tsx
+++ b/apps/user/src/app/login/page.tsx
@@ -10,7 +10,7 @@ import { flex } from '@maru/utils';
 import Link from 'next/link';
 import styled from '@emotion/styled';
 import { useCTAButton, useInput, useKeyDown, useLoginAction } from './login.hook';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useOverlay } from '@toss/use-overlay';
 import { AlertStyleModal } from '@/components/common';
@@ -19,9 +19,10 @@ const Login = () => {
   const router = useRouter();
   const overlay = useOverlay();
   const { isLoggedIn } = useAuthState();
+  const initialIsLoggedIn = useRef(isLoggedIn);
 
   useEffect(() => {
-    if (isLoggedIn) {
+    if (initialIsLoggedIn.current) {
       overlay.open(({ close, isOpen }) => (
         <AlertStyleModal
           isOpen={isOpen}
@@ -41,7 +42,7 @@ const Login = () => {
         />
       ));
     }
-  }, [isLoggedIn, overlay, router]);
+  }, [overlay, router]);
 
   const { handleMoveMainPage } = useCTAButton();
   const { login, handleLoginChange } = useInput();

--- a/apps/user/src/app/login/page.tsx
+++ b/apps/user/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { ROUTES } from '@/constants/common/constants';
 import { AppLayout } from '@/layouts';
 import { color, font } from '@maru/design-system';
 import { IconArrowRight } from '@maru/icon';
+import { useAuthState } from '@maru/hooks';
 import { Button, Column, Input, PreviewInput, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import Link from 'next/link';
@@ -17,10 +18,9 @@ import { AlertStyleModal } from '@/components/common';
 const Login = () => {
   const router = useRouter();
   const overlay = useOverlay();
+  const { isLoggedIn } = useAuthState();
 
   useEffect(() => {
-    const isLoggedIn = !!localStorage.getItem('isLoggedIn');
-
     if (isLoggedIn) {
       overlay.open(({ close, isOpen }) => (
         <AlertStyleModal
@@ -41,7 +41,7 @@ const Login = () => {
         />
       ));
     }
-  }, [overlay, router]);
+  }, [isLoggedIn, overlay, router]);
 
   const { handleMoveMainPage } = useCTAButton();
   const { login, handleLoginChange } = useInput();

--- a/apps/user/src/components/Provider.tsx
+++ b/apps/user/src/components/Provider.tsx
@@ -7,11 +7,12 @@ import type { ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import { Suspense } from 'react';
 import { MobileProvider } from './common';
-import { useToast } from '@maru/hooks';
+import { AuthStateProvider, useToast } from '@maru/hooks';
 import styled from '@emotion/styled';
 
 interface Props {
   children: ReactNode;
+  initialLoggedIn: boolean;
 }
 
 const GlobalToast = () => {
@@ -72,16 +73,18 @@ const StyledToastWrapper = styled.div`
   }
 `;
 
-const Provider = ({ children }: Props) => {
+const Provider = ({ children, initialLoggedIn }: Props) => {
   return (
     <RecoilRoot>
-      <OverlayProvider>
-        <GlobalStyle />
-        <MobileProvider>
-          <Suspense fallback={<Loader />}>{children}</Suspense>
-        </MobileProvider>
-      </OverlayProvider>
-      <GlobalToast />
+      <AuthStateProvider initialLoggedIn={initialLoggedIn}>
+        <OverlayProvider>
+          <GlobalStyle />
+          <MobileProvider>
+            <Suspense fallback={<Loader />}>{children}</Suspense>
+          </MobileProvider>
+          <GlobalToast />
+        </OverlayProvider>
+      </AuthStateProvider>
     </RecoilRoot>
   );
 };

--- a/apps/user/src/components/common/MobileProvider/MobileProvider.tsx
+++ b/apps/user/src/components/common/MobileProvider/MobileProvider.tsx
@@ -2,6 +2,7 @@
 
 import { MobileLogin, MobileMain, MobileResult } from '@/components/mobile';
 import { useStepStore } from '@/stores';
+import { useAuthState } from '@maru/hooks';
 import { SwitchCase } from '@toss/react';
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -13,6 +14,7 @@ interface Props {
 const MobileProvider = ({ children }: Props) => {
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [step, setStep] = useStepStore();
+  const { isLoggedIn } = useAuthState();
 
   useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth <= 700);
@@ -23,14 +25,12 @@ const MobileProvider = ({ children }: Props) => {
   }, []);
 
   useEffect(() => {
-    const isLoggedIn = !!localStorage.getItem('isLoggedIn');
     if (isLoggedIn) {
       if (step === 'LOGIN') setStep('MAIN');
     } else {
       if (step !== 'LOGIN') setStep('LOGIN');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isLoggedIn, setStep, step]);
 
   if (isMobile === null) return null;
 

--- a/apps/user/src/hooks/useLoginGuard.tsx
+++ b/apps/user/src/hooks/useLoginGuard.tsx
@@ -1,5 +1,6 @@
 import { NeedLoginModal } from '@/components/common';
 import { ROUTES } from '@/constants/common/constants';
+import { useAuthState } from '@maru/hooks';
 import { useOverlay } from '@toss/use-overlay';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
@@ -7,10 +8,9 @@ import { useEffect } from 'react';
 const useLoginGuard = () => {
   const router = useRouter();
   const overlay = useOverlay();
+  const { isLoggedIn } = useAuthState();
 
   useEffect(() => {
-    const isLoggedIn = !!localStorage.getItem('isLoggedIn');
-
     if (!isLoggedIn) {
       overlay.open(({ close, isOpen }) => (
         <NeedLoginModal
@@ -26,7 +26,7 @@ const useLoginGuard = () => {
         />
       ));
     }
-  }, [overlay, router]);
+  }, [isLoggedIn, overlay, router]);
 };
 
 export default useLoginGuard;

--- a/apps/user/src/hooks/useLoginGuard.tsx
+++ b/apps/user/src/hooks/useLoginGuard.tsx
@@ -3,15 +3,16 @@ import { ROUTES } from '@/constants/common/constants';
 import { useAuthState } from '@maru/hooks';
 import { useOverlay } from '@toss/use-overlay';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const useLoginGuard = () => {
   const router = useRouter();
   const overlay = useOverlay();
   const { isLoggedIn } = useAuthState();
+  const initialIsLoggedIn = useRef(isLoggedIn);
 
   useEffect(() => {
-    if (!isLoggedIn) {
+    if (!initialIsLoggedIn.current) {
       overlay.open(({ close, isOpen }) => (
         <NeedLoginModal
           isOpen={isOpen}
@@ -26,7 +27,7 @@ const useLoginGuard = () => {
         />
       ));
     }
-  }, [isLoggedIn, overlay, router]);
+  }, [overlay, router]);
 };
 
 export default useLoginGuard;

--- a/apps/user/src/hooks/usePageAccessGuard.tsx
+++ b/apps/user/src/hooks/usePageAccessGuard.tsx
@@ -4,6 +4,7 @@ import { useOverlay } from '@toss/use-overlay';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import { Text } from '@maru/ui';
+import { useAuthState } from '@maru/hooks';
 import { ROUTES } from '@/constants/common/constants';
 import { AlertStyleModal, NeedLoginModal } from '@/components/common';
 
@@ -16,10 +17,10 @@ interface GuardOptions {
 const usePageAccessGuard = (options: GuardOptions) => {
   const router = useRouter();
   const overlay = useOverlay();
+  const { isLoggedIn } = useAuthState();
 
   useEffect(() => {
     const now = dayjs();
-    const isLoggedIn = !!localStorage.getItem('isLoggedIn');
 
     if (!isLoggedIn) {
       overlay.open(({ close, isOpen }) => (
@@ -53,7 +54,7 @@ const usePageAccessGuard = (options: GuardOptions) => {
         />
       ));
     }
-  }, [router, overlay, options]);
+  }, [isLoggedIn, router, overlay, options]);
 };
 
 export default usePageAccessGuard;

--- a/apps/user/src/hooks/usePageAccessGuard.tsx
+++ b/apps/user/src/hooks/usePageAccessGuard.tsx
@@ -7,6 +7,7 @@ import { Text } from '@maru/ui';
 import { useAuthState } from '@maru/hooks';
 import { ROUTES } from '@/constants/common/constants';
 import { AlertStyleModal, NeedLoginModal } from '@/components/common';
+import { useRef } from 'react';
 
 interface GuardOptions {
   period?: { start: Dayjs; end: Dayjs };
@@ -18,11 +19,14 @@ const usePageAccessGuard = (options: GuardOptions) => {
   const router = useRouter();
   const overlay = useOverlay();
   const { isLoggedIn } = useAuthState();
+  const initialIsLoggedIn = useRef(isLoggedIn);
+  const initialOptions = useRef(options);
 
   useEffect(() => {
     const now = dayjs();
+    const guardOptions = initialOptions.current;
 
-    if (!isLoggedIn) {
+    if (!initialIsLoggedIn.current) {
       overlay.open(({ close, isOpen }) => (
         <NeedLoginModal
           isOpen={isOpen}
@@ -36,7 +40,9 @@ const usePageAccessGuard = (options: GuardOptions) => {
           }}
         />
       ));
-    } else if (!now.isBetween(options.period?.start, options.period?.end, 'hour', '[]')) {
+    } else if (
+      !now.isBetween(guardOptions.period?.start, guardOptions.period?.end, 'hour', '[]')
+    ) {
       overlay.open(({ close, isOpen }) => (
         <AlertStyleModal
           isOpen={isOpen}
@@ -44,17 +50,17 @@ const usePageAccessGuard = (options: GuardOptions) => {
             router.replace(ROUTES.MAIN);
             close();
           }}
-          title={options.title ?? ''}
+          title={guardOptions.title ?? ''}
           content={
             <Text fontType="p2" whiteSpace="pre-line">
-              {options.content}
+              {guardOptions.content}
             </Text>
           }
           height={350}
         />
       ));
     }
-  }, [isLoggedIn, router, overlay, options]);
+  }, [router, overlay]);
 };
 
 export default usePageAccessGuard;

--- a/apps/user/src/services/auth/mutations.ts
+++ b/apps/user/src/services/auth/mutations.ts
@@ -5,7 +5,7 @@ import { ROUTES } from '@/constants/common/constants';
 import { useRouter } from 'next/navigation';
 import { useApiError } from '@/hooks';
 import { useSetStepStore } from '@/stores';
-import { useToast } from '@maru/hooks';
+import { useAuthState, useToast } from '@maru/hooks';
 
 export const useLoginMutation = (
   device: string,
@@ -14,11 +14,12 @@ export const useLoginMutation = (
   const router = useRouter();
   const { toast } = useToast();
   const setStep = useSetStepStore();
+  const { setIsLoggedIn } = useAuthState();
 
   const { mutate: loginMutate, ...restMutation } = useMutation({
     mutationFn: () => postLogin({ phoneNumber, password }),
     onSuccess: () => {
-      localStorage.setItem('isLoggedIn', 'true');
+      setIsLoggedIn(true);
       if (device === 'COMPUTER') {
         toast('로그인 되었습니다.', 'SUCCESS');
         router.replace(ROUTES.MAIN);
@@ -40,17 +41,14 @@ export const useLoginMutation = (
 };
 
 export const useLogoutMutation = () => {
-  const router = useRouter();
   const { handleError } = useApiError();
+  const { setIsLoggedIn } = useAuthState();
 
   const { mutate: logoutMutate, ...restMutation } = useMutation({
     mutationFn: deleteLogout,
     onSuccess: () => {
-      localStorage.removeItem('isLoggedIn');
-      router.replace(ROUTES.MAIN);
-      setTimeout(() => {
-        window.location.reload();
-      }, 500);
+      setIsLoggedIn(false);
+      window.location.href = ROUTES.MAIN;
     },
     onError: handleError,
   });

--- a/apps/user/src/services/form/queries.ts
+++ b/apps/user/src/services/form/queries.ts
@@ -9,14 +9,17 @@ import {
 } from './api';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
+import { useAuthState } from '@maru/hooks';
 
 dayjs.extend(isBetween);
 
 export const useFormStatusQuery = () => {
+  const { isLoggedIn } = useAuthState();
+
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.FORM_STATUS],
     queryFn: getFormStatus,
-    enabled: !!localStorage.getItem('isLoggedIn'),
+    enabled: isLoggedIn,
     retry: false,
   });
 
@@ -25,13 +28,12 @@ export const useFormStatusQuery = () => {
 
 export const useExportFormQuery = () => {
   const day = dayjs();
+  const { isLoggedIn } = useAuthState();
 
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.EXPORT_FORM],
     queryFn: getExportForm,
-    enabled:
-      !!localStorage.getItem('isLoggedIn') &&
-      day.isBetween(SCHEDULE.원서_접수, SCHEDULE.원서_접수_마감),
+    enabled: isLoggedIn && day.isBetween(SCHEDULE.원서_접수, SCHEDULE.원서_접수_마감),
     retry: false,
   });
 
@@ -40,13 +42,12 @@ export const useExportFormQuery = () => {
 
 export const useExportReceiptQuery = () => {
   const day = dayjs();
+  const { isLoggedIn } = useAuthState();
 
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.EXPORT_RECEIPT],
     queryFn: getExportReceipt,
-    enabled:
-      !!localStorage.getItem('isLoggedIn') &&
-      day.isBetween(SCHEDULE.원서_접수, SCHEDULE.원서_접수_마감),
+    enabled: isLoggedIn && day.isBetween(SCHEDULE.원서_접수, SCHEDULE.원서_접수_마감),
     retry: false,
   });
 
@@ -54,10 +55,12 @@ export const useExportReceiptQuery = () => {
 };
 
 export const useSaveFormQuery = () => {
+  const { isLoggedIn } = useAuthState();
+
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.SAVE_FORM],
     queryFn: getSaveForm,
-    enabled: !!localStorage.getItem('isLoggedIn'),
+    enabled: isLoggedIn,
     retry: false,
   });
 

--- a/apps/user/src/services/result/queries.ts
+++ b/apps/user/src/services/result/queries.ts
@@ -2,12 +2,15 @@ import { KEY, SCHEDULE } from '@/constants/common/constants';
 import { useQuery } from '@tanstack/react-query';
 import { getAdmissionTicket, getFinalResult, getFirstResult } from './api';
 import dayjs from 'dayjs';
+import { useAuthState } from '@maru/hooks';
 
 export const useFirstResultQuery = () => {
+  const { isLoggedIn } = useAuthState();
+
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.FIRST_RESULT] as const,
     queryFn: getFirstResult,
-    enabled: !!localStorage.getItem('isLoggedIn'),
+    enabled: isLoggedIn,
     retry: false,
   });
 
@@ -15,10 +18,12 @@ export const useFirstResultQuery = () => {
 };
 
 export const useFinalResultQuery = () => {
+  const { isLoggedIn } = useAuthState();
+
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.FINAL_RESULT] as const,
     queryFn: getFinalResult,
-    enabled: !!localStorage.getItem('isLoggedIn'),
+    enabled: isLoggedIn,
     retry: false,
   });
 
@@ -27,13 +32,12 @@ export const useFinalResultQuery = () => {
 
 export const useDownloadAdmissionTicketQuery = () => {
   const day = dayjs();
+  const { isLoggedIn } = useAuthState();
 
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.ADMISSION_TICKET] as const,
     queryFn: getAdmissionTicket,
-    enabled:
-      !!localStorage.getItem('isLoggedIn') &&
-      day.isBetween(SCHEDULE.일차_합격_발표, SCHEDULE.이차_면접),
+    enabled: isLoggedIn && day.isBetween(SCHEDULE.일차_합격_발표, SCHEDULE.이차_면접),
     retry: false,
   });
 

--- a/apps/user/src/services/user/mutations.ts
+++ b/apps/user/src/services/user/mutations.ts
@@ -16,22 +16,19 @@ import type {
   PostUserVerificationReq,
 } from '@/types/user/remote';
 import type { Dispatch, SetStateAction } from 'react';
-import { useToast } from '@maru/hooks';
+import { useAuthState, useToast } from '@maru/hooks';
 
 export const useWithdrawalMutation = (password: string) => {
-  const router = useRouter();
   const { handleError } = useApiError();
   const { toast } = useToast();
+  const { setIsLoggedIn } = useAuthState();
 
   const { mutate: withdrawalMutate, ...restMutation } = useMutation({
     mutationFn: () => deleteUser(password),
     onSuccess: () => {
       toast('회원탈퇴에 성공했습니다.', 'SUCCESS');
-      router.replace(ROUTES.MAIN);
-      setTimeout(() => {
-        window.location.reload();
-      }, 500);
-      localStorage.removeItem('isLoggedIn');
+      setIsLoggedIn(false);
+      window.location.href = ROUTES.MAIN;
     },
     onError: handleError,
   });

--- a/apps/user/src/services/user/queries.ts
+++ b/apps/user/src/services/user/queries.ts
@@ -1,12 +1,15 @@
 import { KEY } from '@/constants/common/constants';
 import { useQuery } from '@tanstack/react-query';
 import { getUser } from './api';
+import { useAuthState } from '@maru/hooks';
 
 export const useUserQuery = () => {
+  const { isLoggedIn } = useAuthState();
+
   const { data, ...restQuery } = useQuery({
     queryKey: [KEY.USER],
     queryFn: getUser,
-    enabled: !!localStorage.getItem('isLoggedIn'),
+    enabled: isLoggedIn,
     retry: false,
   });
 

--- a/packages/hooks/index.ts
+++ b/packages/hooks/index.ts
@@ -1,4 +1,6 @@
 export { default as useBooleanState } from './src/useBooleanState';
+export { AuthStateProvider } from './src/useAuthState';
+export { default as useAuthState } from './src/useAuthState';
 export { default as useDebounceInput } from './src/useDebounceInput';
 export { default as useInterval } from './src/useInterval';
 export { default as useOutsideClick } from './src/useOutsideClick';

--- a/packages/hooks/src/useAuthState.tsx
+++ b/packages/hooks/src/useAuthState.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
+
+interface AuthStateContextValue {
+  isLoggedIn: boolean;
+  setIsLoggedIn: (value: boolean) => void;
+}
+
+const AuthStateContext = createContext<AuthStateContextValue | null>(null);
+
+interface AuthStateProviderProps {
+  children: ReactNode;
+  initialLoggedIn?: boolean;
+}
+
+export const AuthStateProvider = ({
+  children,
+  initialLoggedIn = false,
+}: AuthStateProviderProps) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(initialLoggedIn);
+
+  const value = useMemo(
+    () => ({
+      isLoggedIn,
+      setIsLoggedIn,
+    }),
+    [isLoggedIn, setIsLoggedIn],
+  );
+
+  return <AuthStateContext.Provider value={value}>{children}</AuthStateContext.Provider>;
+};
+
+const useAuthState = () => {
+  const value = useContext(AuthStateContext);
+
+  if (!value) {
+    throw new Error('useAuthState must be used within AuthStateProvider');
+  }
+
+  return value;
+};
+
+export default useAuthState;


### PR DESCRIPTION
## 📄 Summary

> `localStorage` 기반 인증 상태 관리를 `useAuthState` Context로 전환합니다.                                                                                                                                                               
서버 컴포넌트(`layout.tsx`)에서 쿠키를 읽어 초기 로그인 상태를 주입하고,
클라이언트에서는 Context를 통해 인증 상태를 구독·변경합니다.     

<br>

## 🔨 Tasks

-  `packages/hooks`에 `useAuthState` 훅 및 `AuthStateProvider` 추가
- `layout.tsx`에서 `cookies()`로 서버 사이드 초기 인증 상태 주입
- `localStorage.getItem('isLoggedIn')` → `useAuthState().isLoggedIn` 전환 (admin, user 전체)
- `localStorage.setItem/removeItem` → `setIsLoggedIn(true/false)` 전환                                                                                                                                                                                                                      
-  admin `instance.ts` 토큰 갱신 로직을 user와 동일한 `failedQueue` 패턴으로 통일                  

<br>

## 🙋🏻 More
 `localStorage`는 SSR 환경에서 접근할 수 없어 hydration 불일치가 발생할 수 있고,                                                                                                                                                           
  HttpOnly 쿠키 전환 이후 클라이언트에서 직접 인증 여부를 판단할 수 있는 신뢰할 수 있는 수단이 없었습니다.
                                                                                                                                                                                                                                            
  이번 변경으로 서버에서 쿠키 존재 여부를 읽어 `initialLoggedIn`으로 Context에 주입하고,                                                                                                                                                    
  이후 로그인·로그아웃 시 `setIsLoggedIn`으로 클라이언트 상태를 동기화합니다.                                                                                                                                                               
  페이지 이동·새로고침 시에는 layout이 다시 쿠키를 읽어 초기화되므로 상태 불일치가 발생하지 않습니다. 